### PR TITLE
228 fix all tests in trovemanager recoverymodetestjs related to the multi asset feature

### DIFF
--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -407,7 +407,7 @@ contract BorrowerOperations is KumoBase, CheckContract, IBorrowerOperations {
         contractsCache.troveManager.applyPendingRewards(vars.asset, _borrower);
 
         // Get the collChange based on whether or not ETH was sent in the transaction
-        (vars.collChange, vars.isCollIncrease) = _getCollChange(msg.value, _collWithdrawal);
+        (vars.collChange, vars.isCollIncrease) = _getCollChange(_assetSent, _collWithdrawal);
 
         vars.netDebtChange = _KUSDChange;
 
@@ -707,7 +707,7 @@ contract BorrowerOperations is KumoBase, CheckContract, IBorrowerOperations {
         uint256 _amountSent
     ) internal view {
         require(
-            msg.value != 0 || _collWithdrawal != 0 || _KUSDChange != 0 || _amountSent != 0,
+             _collWithdrawal != 0 || _KUSDChange != 0 || _amountSent != 0,
             "BorrowerOps: There must be either a collateral change or a debt change"
         );
     }

--- a/packages/contracts/contracts/Interfaces/IStabilityPool.sol
+++ b/packages/contracts/contracts/Interfaces/IStabilityPool.sol
@@ -35,10 +35,9 @@ import "./IDeposit.sol";
  * Please see the system Readme for an overview:
  * https://github.com/liquity/dev/blob/main/README.md#kumo-issuance-to-stability-providers
  */
-interface IStabilityPool is IDeposit{
-
+interface IStabilityPool is IDeposit {
     // --- Events ---
-    
+
     event StabilityPoolAssetBalanceUpdated(uint256 _newBalance);
     event StabilityPoolKUSDBalanceUpdated(uint256 _newBalance);
 
@@ -56,14 +55,18 @@ interface IStabilityPool is IDeposit{
     event G_Updated(uint256 _G, uint128 _epoch, uint128 _scale);
     event EpochUpdated(uint128 _currentEpoch);
     event ScaleUpdated(uint128 _currentScale);
-    
+
     //  FrontEnd
 
-    event FrontEndRegistered(address indexed _frontEnd, uint _kickbackRate);
+    event FrontEndRegistered(address indexed _frontEnd, uint256 _kickbackRate);
     event FrontEndTagSet(address indexed _depositor, address indexed _frontEnd);
-    event FrontEndSnapshotUpdated(address indexed _frontEnd, uint _P, uint _G);
-    event FrontEndStakeChanged(address indexed _frontEnd, uint _newFrontEndStake, address _depositor);
-    event KUMOPaidToFrontEnd(address indexed _frontEnd, uint _KUMO);
+    event FrontEndSnapshotUpdated(address indexed _frontEnd, uint256 _P, uint256 _G);
+    event FrontEndStakeChanged(
+        address indexed _frontEnd,
+        uint256 _newFrontEndStake,
+        address _depositor
+    );
+    event KUMOPaidToFrontEnd(address indexed _frontEnd, uint256 _KUMO);
 
     event DepositSnapshotUpdated(address indexed _depositor, uint256 _P, uint256 _S, uint256 _G);
     event UserDepositChanged(address indexed _depositor, uint256 _newDeposit);
@@ -72,7 +75,6 @@ interface IStabilityPool is IDeposit{
     event AssetGainWithdrawn(address indexed _depositor, uint256 _Asset, uint256 _kusdLoss);
     event SystemSnapshotUpdated(uint256 _P, uint256 _G);
 
-    event ETHGainWithdrawn(address indexed _depositor, uint256 _ETH, uint256 _kusdLoss);
     event KUMOPaidToDepositor(address indexed _depositor, uint256 _KUMO);
     event AssetSent(address _to, uint256 _amount);
 
@@ -90,7 +92,6 @@ interface IStabilityPool is IDeposit{
         address _sortedTrovesAddress,
         address _communityIssuanceAddress,
         address _kumoParamsAddress
-
     ) external;
 
     /*
@@ -168,7 +169,6 @@ interface IStabilityPool is IDeposit{
      */
     function getTotalKUSDDeposits() external view returns (uint256);
 
-
     /*
      * Calculate the KUMO gain earned by a deposit since its last snapshots were taken.
      * If not tagged with a front end, the depositor gets a 100% cut of what their deposit earned.
@@ -194,21 +194,21 @@ interface IStabilityPool is IDeposit{
      */
     function getCompoundedFrontEndStake(address _frontEnd) external view returns (uint256);
 
-	/*
-	 * Calculates the ETH gain earned by the deposit since its last snapshots were taken.
-	 */
-	function getDepositorAssetGain(address _depositor) external view returns (uint256);
+    /*
+     * Calculates the ETH gain earned by the deposit since its last snapshots were taken.
+     */
+    function getDepositorAssetGain(address _depositor) external view returns (uint256);
 
-	/*
-	 * Return the front end's compounded stake.
-	 *
-	 * The front end's compounded stake is equal to the sum of its depositors' compounded deposits.
-	 */
-	function getCompoundedTotalStake() external view returns (uint256);
+    /*
+     * Return the front end's compounded stake.
+     *
+     * The front end's compounded stake is equal to the sum of its depositors' compounded deposits.
+     */
+    function getCompoundedTotalStake() external view returns (uint256);
 
-	function getNameBytes() external view returns (bytes32);
+    function getNameBytes() external view returns (bytes32);
 
-	function getAssetType() external view returns (address);
+    function getAssetType() external view returns (address);
 
     /*
      * Fallback function

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.11;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
-import './Interfaces/IBorrowerOperations.sol';
-import './Interfaces/IStabilityPool.sol';
-import './Interfaces/IBorrowerOperations.sol';
-import './Interfaces/ITroveManager.sol';
-import './Interfaces/IKUSDToken.sol';
-import './Interfaces/ISortedTroves.sol';
+import "./Interfaces/IBorrowerOperations.sol";
+import "./Interfaces/IStabilityPool.sol";
+import "./Interfaces/IBorrowerOperations.sol";
+import "./Interfaces/ITroveManager.sol";
+import "./Interfaces/IKUSDToken.sol";
+import "./Interfaces/ISortedTroves.sol";
 import "./Interfaces/ICommunityIssuance.sol";
 import "./Dependencies/KumoBase.sol";
 import "./Dependencies/SafeMath.sol";
@@ -17,7 +17,6 @@ import "./Dependencies/KumoSafeMath128.sol";
 import "./Dependencies/CheckContract.sol";
 import "./Dependencies/console.sol";
 import "./Dependencies/SafetyTransfer.sol";
-
 
 /*
  * The Stability Pool holds KUSD tokens deposited by Stability Pool depositors.
@@ -72,9 +71,9 @@ import "./Dependencies/SafetyTransfer.sol";
  * So, to track P accurately, we use a scale factor: if a liquidation would cause P to decrease to <1e-9 (and be rounded to 0 by Solidity),
  * we first multiply P by 1e9, and increment a currentScale factor by 1.
  *
- * The added benefit of using 1e9 for the scale factor (rather than 1e18) is that it ensures negligible precision loss close to the 
- * scale boundary: when P is at its minimum value of 1e9, the relative precision loss in P due to floor division is only on the 
- * order of 1e-9. 
+ * The added benefit of using 1e9 for the scale factor (rather than 1e18) is that it ensures negligible precision loss close to the
+ * scale boundary: when P is at its minimum value of 1e9, the relative precision loss in P due to floor division is only on the
+ * order of 1e-9.
  *
  * --- EPOCHS ---
  *
@@ -155,9 +154,9 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
 
     // bool public isInitialized;
 
-    string constant public NAME = "StabilityPool";
+    string public constant NAME = "StabilityPool";
     bytes32 public constant STABILITY_POOL_NAME_BYTES =
-		0xf704b47f65a99b2219b7213612db4be4a436cdf50624f4baca1373ef0de0aac7;
+        0xf704b47f65a99b2219b7213612db4be4a436cdf50624f4baca1373ef0de0aac7;
 
     IBorrowerOperations public borrowerOperations;
 
@@ -172,12 +171,12 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
 
     address internal assetAddress;
 
-	uint256 internal assetBalance; // deposited ether tracker
+    uint256 internal assetBalance; // deposited ether tracker
 
     // Tracker for KUSD held in the pool. Changes when users deposit/withdraw, and when Trove debt is offset.
     uint256 internal totalKUSDDeposits;
 
-   // --- Data structures ---
+    // --- Data structures ---
 
     struct FrontEnd {
         uint256 kickbackRate;
@@ -185,7 +184,7 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
     }
 
     struct Deposit {
-        uint initialValue;
+        uint256 initialValue;
         address frontEndTag;
     }
 
@@ -198,21 +197,21 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
     }
 
     uint256 public totalStakes;
-	Snapshots public systemSnapshots;
+    Snapshots public systemSnapshots;
 
-    mapping (address => Deposit) public deposits;  // depositor address -> Deposit struct
-    mapping (address => Snapshots) public depositSnapshots;  // depositor address -> snapshots struct
+    mapping(address => Deposit) public deposits; // depositor address -> Deposit struct
+    mapping(address => Snapshots) public depositSnapshots; // depositor address -> snapshots struct
 
-    mapping (address => FrontEnd) public frontEnds;  // front end address -> FrontEnd struct
-    mapping (address => uint256) public frontEndStakes; // front end address -> last recorded total deposits, tagged with that front end
-    mapping (address => Snapshots) public frontEndSnapshots; // front end address -> snapshots struct
+    mapping(address => FrontEnd) public frontEnds; // front end address -> FrontEnd struct
+    mapping(address => uint256) public frontEndStakes; // front end address -> last recorded total deposits, tagged with that front end
+    mapping(address => Snapshots) public frontEndSnapshots; // front end address -> snapshots struct
 
     /*  Product 'P': Running product by which to multiply an initial deposit, in order to find the current compounded deposit,
-    * after a series of liquidations have occurred, each of which cancel some KUSD debt with the deposit.
-    *
-    * During its lifetime, a deposit's value evolves from d_t to d_t * P / P_t , where P_t
-    * is the snapshot of P taken at the instant the deposit was made. 18-digit decimal.
-    */
+     * after a series of liquidations have occurred, each of which cancel some KUSD debt with the deposit.
+     *
+     * During its lifetime, a deposit's value evolves from d_t to d_t * P / P_t , where P_t
+     * is the snapshot of P taken at the instant the deposit was made. 18-digit decimal.
+     */
     uint256 public P = DECIMAL_PRECISION;
 
     uint256 public constant SCALE_FACTOR = 1e9;
@@ -224,38 +223,38 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
     uint128 public currentEpoch;
 
     /* ETH Gain sum 'S': During its lifetime, each deposit d_t earns an ETH gain of ( d_t * [S - S_t] )/P_t, where S_t
-    * is the depositor's snapshot of S taken at the time t when the deposit was made.
-    *
-    * The 'S' sums are stored in a nested mapping (epoch => scale => sum):
-    *
-    * - The inner mapping records the sum S at different scales
-    * - The outer mapping records the (scale => sum) mappings, for different epochs.
-    */
-    mapping (uint128 => mapping(uint128 => uint256)) public epochToScaleToSum;
+     * is the depositor's snapshot of S taken at the time t when the deposit was made.
+     *
+     * The 'S' sums are stored in a nested mapping (epoch => scale => sum):
+     *
+     * - The inner mapping records the sum S at different scales
+     * - The outer mapping records the (scale => sum) mappings, for different epochs.
+     */
+    mapping(uint128 => mapping(uint128 => uint256)) public epochToScaleToSum;
 
     /*
-    * Similarly, the sum 'G' is used to calculate KUMO gains. During it's lifetime, each deposit d_t earns a KUMO gain of
-    *  ( d_t * [G - G_t] )/P_t, where G_t is the depositor's snapshot of G taken at time t when  the deposit was made.
-    *
-    *  KUMO reward events occur are triggered by depositor operations (new deposit, topup, withdrawal), and liquidations.
-    *  In each case, the KUMO reward is issued (i.e. G is updated), before other state changes are made.
-    */
-    mapping (uint128 => mapping(uint128 => uint256)) public epochToScaleToG;
+     * Similarly, the sum 'G' is used to calculate KUMO gains. During it's lifetime, each deposit d_t earns a KUMO gain of
+     *  ( d_t * [G - G_t] )/P_t, where G_t is the depositor's snapshot of G taken at time t when  the deposit was made.
+     *
+     *  KUMO reward events occur are triggered by depositor operations (new deposit, topup, withdrawal), and liquidations.
+     *  In each case, the KUMO reward is issued (i.e. G is updated), before other state changes are made.
+     */
+    mapping(uint128 => mapping(uint128 => uint256)) public epochToScaleToG;
 
     // Error tracker for the error correction in the KUMO issuance calculation
     uint256 public lastKUMOError;
     // Error trackers for the error correction in the offset calculation
     uint256 public lastETHError_Offset;
-    uint256 public lastkusdLossError_Offset;
+    uint256 public lastKUSDLossError_Offset;
 
     // --- Contract setters ---
     function getNameBytes() external pure override returns (bytes32) {
-		return STABILITY_POOL_NAME_BYTES;
-	}
+        return STABILITY_POOL_NAME_BYTES;
+    }
 
-	function getAssetType() external view override returns (address) {
-		return assetAddress;
-	}
+    function getAssetType() external view override returns (address) {
+        return assetAddress;
+    }
 
     function setAddresses(
         address _assetAddress,
@@ -265,11 +264,7 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
         address _sortedTrovesAddress,
         address _communityIssuanceAddress,
         address _kumoParamsAddress
-    )
-        external
-        override
-        onlyOwner
-    {
+    ) external override onlyOwner {
         // require(!isInitialized, "Already initialized");
         checkContract(_borrowerOperationsAddress);
         checkContract(_troveManagerAddress);
@@ -278,12 +273,12 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
         checkContract(_communityIssuanceAddress);
         checkContract(_kumoParamsAddress);
 
-		// isInitialized = true;
-		// __Ownable_init();
+        // isInitialized = true;
+        // __Ownable_init();
         if (_assetAddress != ETH_REF_ADDRESS) {
-			checkContract(_assetAddress);
-		}
-		assetAddress = _assetAddress;
+            checkContract(_assetAddress);
+        }
+        assetAddress = _assetAddress;
 
         borrowerOperations = IBorrowerOperations(_borrowerOperationsAddress);
         troveManager = ITroveManager(_troveManagerAddress);
@@ -308,75 +303,76 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
         return assetBalance;
     }
 
-    function getTotalKUSDDeposits() external view override returns (uint256){
+    function getTotalKUSDDeposits() external view override returns (uint256) {
         return totalKUSDDeposits;
     }
 
     // --- External Depositor Functions ---
 
     /*  provideToSP():
-    *
-    * - Triggers a KUMO issuance, based on time passed since the last issuance. The KUMO issuance is shared between *all* depositors and front ends
-    * - Tags the deposit with the provided front end tag param, if it's a new deposit
-    * - Sends depositor's accumulated gains (KUMO, ETH) to depositor
-    * - Sends the tagged front end's accumulated KUMO gains to the tagged front end
-    * - Increases deposit and tagged front end's stake, and takes new snapshots for each.
-    */
-    	function provideToSP(uint256 _amount, address _frontEndTag) external override {
+     *
+     * - Triggers a KUMO issuance, based on time passed since the last issuance. The KUMO issuance is shared between *all* depositors and front ends
+     * - Tags the deposit with the provided front end tag param, if it's a new deposit
+     * - Sends depositor's accumulated gains (KUMO, ETH) to depositor
+     * - Sends the tagged front end's accumulated KUMO gains to the tagged front end
+     * - Increases deposit and tagged front end's stake, and takes new snapshots for each.
+     */
+    function provideToSP(uint256 _amount, address _frontEndTag) external override {
         _requireFrontEndIsRegisteredOrZero(_frontEndTag);
         _requireFrontEndNotRegistered(msg.sender);
-		_requireNonZeroAmount(_amount);
+        _requireNonZeroAmount(_amount);
 
-		uint256 initialDeposit = deposits[msg.sender].initialValue;
+        uint256 initialDeposit = deposits[msg.sender].initialValue;
 
-		ICommunityIssuance communityIssuanceCached = communityIssuance;
-		_triggerKUMOIssuance(communityIssuanceCached);
+        ICommunityIssuance communityIssuanceCached = communityIssuance;
+        _triggerKUMOIssuance(communityIssuanceCached);
 
-		uint256 depositorAssetGain = getDepositorAssetGain(msg.sender);
-		uint256 depositorAssetGainEther = getDepositorAssetGain1e18(msg.sender);
+        uint256 depositorAssetGain = getDepositorAssetGain(msg.sender);
 
-		uint256 compoundedKUSDDeposit = getCompoundedKUSDDeposit(msg.sender);
-		uint256 KUSDLoss = initialDeposit.sub(compoundedKUSDDeposit); // Needed only for event log
+        uint256 compoundedKUSDDeposit = getCompoundedKUSDDeposit(msg.sender);
+        uint256 KUSDLoss = initialDeposit.sub(compoundedKUSDDeposit); // Needed only for event log
 
         // First pay out any KUMO gains
         address frontEnd = deposits[msg.sender].frontEndTag;
         _payOutKUMOGains(communityIssuanceCached, msg.sender, frontEnd);
 
         // Update front end stake
-        uint compoundedFrontEndStake = getCompoundedFrontEndStake(frontEnd);
-        uint newFrontEndStake = compoundedFrontEndStake.add(_amount);
+        uint256 compoundedFrontEndStake = getCompoundedFrontEndStake(frontEnd);
+        uint256 newFrontEndStake = compoundedFrontEndStake.add(_amount);
         _updateFrontEndStakeAndSnapshots(frontEnd, newFrontEndStake);
         emit FrontEndStakeChanged(frontEnd, newFrontEndStake, msg.sender);
 
-		// Update System stake
-		uint256 compoundedStake = getCompoundedTotalStake();
-		uint256 newStake = compoundedStake.add(_amount);
-		_updateStakeAndSnapshots(newStake);
-		emit StakeChanged(newStake, msg.sender);
+        // Update System stake
+        uint256 compoundedStake = getCompoundedTotalStake();
+        uint256 newStake = compoundedStake.add(_amount);
+        _updateStakeAndSnapshots(newStake);
+        emit StakeChanged(newStake, msg.sender);
 
-		_sendKUSDtoStabilityPool(msg.sender, _amount);
+        _sendKUSDtoStabilityPool(msg.sender, _amount);
 
-		uint256 newDeposit = compoundedKUSDDeposit.add(_amount);
-		_updateDepositAndSnapshots(msg.sender, newDeposit);
+        uint256 newDeposit = compoundedKUSDDeposit.add(_amount);
+        _updateDepositAndSnapshots(msg.sender, newDeposit);
 
-		emit UserDepositChanged(msg.sender, newDeposit);
-		emit AssetGainWithdrawn(msg.sender, depositorAssetGain, KUSDLoss); // KUSD Loss required for event log
+        emit UserDepositChanged(msg.sender, newDeposit);
+        emit AssetGainWithdrawn(msg.sender, depositorAssetGain, KUSDLoss); // KUSD Loss required for event log
 
-		_sendAssetGainToDepositor(depositorAssetGain, depositorAssetGainEther);
-     }
+        _sendAssetGainToDepositor(depositorAssetGain);
+    }
 
     /*  withdrawFromSP():
-    *
-    * - Triggers a KUMO issuance, based on time passed since the last issuance. The KUMO issuance is shared between *all* depositors and front ends
-    * - Removes the deposit's front end tag if it is a full withdrawal
-    * - Sends all depositor's accumulated gains (KUMO, ETH) to depositor
-    * - Sends the tagged front end's accumulated KUMO gains to the tagged front end
-    * - Decreases deposit and tagged front end's stake, and takes new snapshots for each.
-    *
-    * If _amount > userDeposit, the user withdraws all of their compounded deposit.
-    */
+     *
+     * - Triggers a KUMO issuance, based on time passed since the last issuance. The KUMO issuance is shared between *all* depositors and front ends
+     * - Removes the deposit's front end tag if it is a full withdrawal
+     * - Sends all depositor's accumulated gains (KUMO, ETH) to depositor
+     * - Sends the tagged front end's accumulated KUMO gains to the tagged front end
+     * - Decreases deposit and tagged front end's stake, and takes new snapshots for each.
+     *
+     * If _amount > userDeposit, the user withdraws all of their compounded deposit.
+     */
     function withdrawFromSP(uint256 _amount) external override {
-        if (_amount !=0) {_requireNoUnderCollateralizedTroves();}
+        if (_amount != 0) {
+            _requireNoUnderCollateralizedTroves();
+        }
         uint256 initialDeposit = deposits[msg.sender].initialValue;
         _requireUserHasDeposit(initialDeposit);
 
@@ -384,22 +380,22 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
 
         _triggerKUMOIssuance(communityIssuanceCached);
 
-        uint256 depositorETHGain = getDepositorAssetGain(msg.sender);
+        uint256 depositorAssetGain = getDepositorAssetGain(msg.sender);
 
         uint256 compoundedKUSDDeposit = getCompoundedKUSDDeposit(msg.sender);
         uint256 KUSDtoWithdraw = KumoMath._min(_amount, compoundedKUSDDeposit);
-        uint256 kusdLoss = initialDeposit.sub(compoundedKUSDDeposit); // Needed only for event log
+        uint256 KUSDLoss = initialDeposit.sub(compoundedKUSDDeposit); // Needed only for event log
 
         // First pay out any KUMO gains
         address frontEnd = deposits[msg.sender].frontEndTag;
         _payOutKUMOGains(communityIssuanceCached, msg.sender, frontEnd);
-        
+
         // Update front end stake
-		// Update System stake
-		uint256 compoundedStake = getCompoundedTotalStake();
-		uint256 newStake = compoundedStake.sub(KUSDtoWithdraw);
-		_updateStakeAndSnapshots(newStake);
-		emit StakeChanged(newStake, msg.sender);
+        // Update System stake
+        uint256 compoundedStake = getCompoundedTotalStake();
+        uint256 newStake = compoundedStake.sub(KUSDtoWithdraw);
+        _updateStakeAndSnapshots(newStake);
+        emit StakeChanged(newStake, msg.sender);
 
         _sendKUSDToDepositor(msg.sender, KUSDtoWithdraw);
 
@@ -408,96 +404,102 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
         _updateDepositAndSnapshots(msg.sender, newDeposit);
         emit UserDepositChanged(msg.sender, newDeposit);
 
-        emit ETHGainWithdrawn(msg.sender, depositorETHGain, kusdLoss);  // KUSD Loss required for event log
+        emit AssetGainWithdrawn(msg.sender, depositorAssetGain, KUSDLoss); // KUSD Loss required for event log
 
-        _sendETHGainToDepositor(depositorETHGain);
+        _sendAssetGainToDepositor(depositorAssetGain);
     }
 
     /* withdrawETHGainToTrove:
-    * - Triggers a KUMO issuance, based on time passed since the last issuance. The KUMO issuance is shared between *all* depositors and front ends
-    * - Sends all depositor's KUMO gain to  depositor
-    * - Sends all tagged front end's KUMO gain to the tagged front end
-    * - Transfers the depositor's entire ETH gain from the Stability Pool to the caller's trove
-    * - Leaves their compounded deposit in the Stability Pool
-    * - Updates snapshots for deposit and tagged front end stake */
+     * - Triggers a KUMO issuance, based on time passed since the last issuance. The KUMO issuance is shared between *all* depositors and front ends
+     * - Sends all depositor's KUMO gain to  depositor
+     * - Sends all tagged front end's KUMO gain to the tagged front end
+     * - Transfers the depositor's entire ETH gain from the Stability Pool to the caller's trove
+     * - Leaves their compounded deposit in the Stability Pool
+     * - Updates snapshots for deposit and tagged front end stake */
     function withdrawETHGainToTrove(address _upperHint, address _lowerHint) external override {
         uint256 initialDeposit = deposits[msg.sender].initialValue;
         _requireUserHasDeposit(initialDeposit);
         _requireUserHasTrove(msg.sender);
-        _requireUserHasETHGain(msg.sender);
+        _requireUserHasAssetGain(msg.sender);
 
         ICommunityIssuance communityIssuanceCached = communityIssuance;
 
         _triggerKUMOIssuance(communityIssuanceCached);
 
-        uint256 depositorAssetGain = getDepositorAssetGain1e18(msg.sender);
+        uint256 depositorAssetGain = getDepositorAssetGain(msg.sender);
 
-		uint256 compoundedKUSDDeposit = getCompoundedKUSDDeposit(msg.sender);
-        uint256 kusdLoss = initialDeposit.sub(compoundedKUSDDeposit); // Needed only for event log
+        uint256 compoundedKUSDDeposit = getCompoundedKUSDDeposit(msg.sender);
+        uint256 KUSDLoss = initialDeposit.sub(compoundedKUSDDeposit); // Needed only for event log
 
         // First pay out any KUMO gains
         address frontEnd = deposits[msg.sender].frontEndTag;
         _payOutKUMOGains(communityIssuanceCached, msg.sender, frontEnd);
 
         // Update System stake
-		uint256 compoundedSystemStake = getCompoundedTotalStake();
-		_updateStakeAndSnapshots(compoundedSystemStake);
-		emit StakeChanged(compoundedSystemStake, msg.sender);
+        uint256 compoundedSystemStake = getCompoundedTotalStake();
+        _updateStakeAndSnapshots(compoundedSystemStake);
+        emit StakeChanged(compoundedSystemStake, msg.sender);
 
         _updateDepositAndSnapshots(msg.sender, compoundedKUSDDeposit);
 
         /* Emit events before transferring ETH gain to Trove.
          This lets the event log make more sense (i.e. so it appears that first the ETH gain is withdrawn
         and then it is deposited into the Trove, not the other way around). */
-        emit AssetGainWithdrawn(msg.sender, depositorAssetGain, kusdLoss);
+        emit AssetGainWithdrawn(msg.sender, depositorAssetGain, KUSDLoss);
         emit UserDepositChanged(msg.sender, compoundedKUSDDeposit);
 
-		assetBalance = assetBalance.sub(depositorAssetGain);
-		emit StabilityPoolAssetBalanceUpdated(assetBalance);
-		emit AssetSent(msg.sender, depositorAssetGain);
+        assetBalance = assetBalance.sub(depositorAssetGain);
+        emit StabilityPoolAssetBalanceUpdated(assetBalance);
+        emit AssetSent(msg.sender, depositorAssetGain);
 
-		borrowerOperations.moveETHGainToTrove{
-			value: assetAddress == address(0) ? depositorAssetGain : 0
-		}(assetAddress, depositorAssetGain, msg.sender, _upperHint, _lowerHint);
+        borrowerOperations.moveETHGainToTrove{
+            value: assetAddress == address(0) ? depositorAssetGain : 0
+        }(assetAddress, depositorAssetGain, msg.sender, _upperHint, _lowerHint);
     }
 
     // --- KUMO issuance functions ---
 
     function _triggerKUMOIssuance(ICommunityIssuance _communityIssuance) internal {
         uint256 KUMOIssuance = _communityIssuance.issueKUMO();
-       _updateG(KUMOIssuance);
+        _updateG(KUMOIssuance);
     }
 
     function _updateG(uint256 _KUMOIssuance) internal {
         uint256 totalKUSD = totalKUSDDeposits; // cached to save an SLOAD
         /*
-        * When total deposits is 0, G is not updated. In this case, the KUMO issued can not be obtained by later
-        * depositors - it is missed out on, and remains in the balanceof the CommunityIssuance contract.
-        *
-        */
-        if (totalKUSD == 0 || _KUMOIssuance == 0) {return;}
+         * When total deposits is 0, G is not updated. In this case, the KUMO issued can not be obtained by later
+         * depositors - it is missed out on, and remains in the balanceof the CommunityIssuance contract.
+         *
+         */
+        if (totalKUSD == 0 || _KUMOIssuance == 0) {
+            return;
+        }
 
         uint256 KUMOPerUnitStaked;
-        KUMOPerUnitStaked =_computeKUMOPerUnitStaked(_KUMOIssuance, totalKUSD);
+        KUMOPerUnitStaked = _computeKUMOPerUnitStaked(_KUMOIssuance, totalKUSD);
 
         uint256 marginalKUMOGain = KUMOPerUnitStaked.mul(P);
-        epochToScaleToG[currentEpoch][currentScale] = epochToScaleToG[currentEpoch][currentScale].add(marginalKUMOGain);
+        epochToScaleToG[currentEpoch][currentScale] = epochToScaleToG[currentEpoch][currentScale]
+            .add(marginalKUMOGain);
 
         emit G_Updated(epochToScaleToG[currentEpoch][currentScale], currentEpoch, currentScale);
     }
 
-    function _computeKUMOPerUnitStaked(uint256 _KUMOIssuance, uint256 _totalKUSDDeposits) internal returns (uint256) {
-        /*  
-        * Calculate the KUMO-per-unit staked.  Division uses a "feedback" error correction, to keep the 
-        * cumulative error low in the running total G:
-        *
-        * 1) Form a numerator which compensates for the floor division error that occurred the last time this 
-        * function was called.  
-        * 2) Calculate "per-unit-staked" ratio.
-        * 3) Multiply the ratio back by its denominator, to reveal the current floor division error.
-        * 4) Store this error for use in the next correction when this function is called.
-        * 5) Note: static analysis tools complain about this "division before multiplication", however, it is intended.
-        */
+    function _computeKUMOPerUnitStaked(uint256 _KUMOIssuance, uint256 _totalKUSDDeposits)
+        internal
+        returns (uint256)
+    {
+        /*
+         * Calculate the KUMO-per-unit staked.  Division uses a "feedback" error correction, to keep the
+         * cumulative error low in the running total G:
+         *
+         * 1) Form a numerator which compensates for the floor division error that occurred the last time this
+         * function was called.
+         * 2) Calculate "per-unit-staked" ratio.
+         * 3) Multiply the ratio back by its denominator, to reveal the current floor division error.
+         * 4) Store this error for use in the next correction when this function is called.
+         * 5) Note: static analysis tools complain about this "division before multiplication", however, it is intended.
+         */
         uint256 KUMONumerator = _KUMOIssuance.mul(DECIMAL_PRECISION).add(lastKUMOError);
 
         uint256 KUMOPerUnitStaked = KUMONumerator.div(_totalKUSDDeposits);
@@ -509,21 +511,26 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
     // --- Liquidation functions ---
 
     /*
-    * Cancels out the specified debt against the KUSD contained in the Stability Pool (as far as possible)
-    * and transfers the Trove's ETH collateral from ActivePool to StabilityPool.
-    * Only called by liquidation functions in the TroveManager.
-    */
+     * Cancels out the specified debt against the KUSD contained in the Stability Pool (as far as possible)
+     * and transfers the Trove's ETH collateral from ActivePool to StabilityPool.
+     * Only called by liquidation functions in the TroveManager.
+     */
     function offset(uint256 _debtToOffset, uint256 _collToAdd) external override {
         _requireCallerIsTroveManager();
         uint256 totalKUSD = totalKUSDDeposits; // cached to save an SLOAD
-        if (totalKUSD == 0 || _debtToOffset == 0) { return; }
+        if (totalKUSD == 0 || _debtToOffset == 0) {
+            return;
+        }
 
         _triggerKUMOIssuance(communityIssuance);
 
-        (uint256 ETHGainPerUnitStaked,
-            uint256 kusdLossPerUnitStaked) = _computeRewardsPerUnitStaked(_collToAdd, _debtToOffset, totalKUSD);
+        (uint256 ETHGainPerUnitStaked, uint256 KUSDLossPerUnitStaked) = _computeRewardsPerUnitStaked(
+            _collToAdd,
+            _debtToOffset,
+            totalKUSD
+        );
 
-        _updateRewardSumAndProduct(ETHGainPerUnitStaked, kusdLossPerUnitStaked);  // updates S and P
+        _updateRewardSumAndProduct(ETHGainPerUnitStaked, KUSDLossPerUnitStaked); // updates S and P
 
         _moveOffsetCollAndDebt(_collToAdd, _debtToOffset);
     }
@@ -534,66 +541,70 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
         uint256 _collToAdd,
         uint256 _debtToOffset,
         uint256 _totalKUSDDeposits
-    )
-        internal
-        returns (uint256 ETHGainPerUnitStaked, uint256 kusdLossPerUnitStaked)
-    {
+    ) internal returns (uint256 ETHGainPerUnitStaked, uint256 KUSDLossPerUnitStaked) {
         /*
-        * Compute the KUSD and ETH rewards. Uses a "feedback" error correction, to keep
-        * the cumulative error in the P and S state variables low:
-        *
-        * 1) Form numerators which compensate for the floor division errors that occurred the last time this 
-        * function was called.  
-        * 2) Calculate "per-unit-staked" ratios.
-        * 3) Multiply each ratio back by its denominator, to reveal the current floor division error.
-        * 4) Store these errors for use in the next correction when this function is called.
-        * 5) Note: static analysis tools complain about this "division before multiplication", however, it is intended.
-        */
+         * Compute the KUSD and ETH rewards. Uses a "feedback" error correction, to keep
+         * the cumulative error in the P and S state variables low:
+         *
+         * 1) Form numerators which compensate for the floor division errors that occurred the last time this
+         * function was called.
+         * 2) Calculate "per-unit-staked" ratios.
+         * 3) Multiply each ratio back by its denominator, to reveal the current floor division error.
+         * 4) Store these errors for use in the next correction when this function is called.
+         * 5) Note: static analysis tools complain about this "division before multiplication", however, it is intended.
+         */
         uint256 ETHNumerator = _collToAdd.mul(DECIMAL_PRECISION).add(lastETHError_Offset);
 
         assert(_debtToOffset <= _totalKUSDDeposits);
         if (_debtToOffset == _totalKUSDDeposits) {
-            kusdLossPerUnitStaked = DECIMAL_PRECISION;  // When the Pool depletes to 0, so does each deposit 
-            lastkusdLossError_Offset = 0;
+            KUSDLossPerUnitStaked = DECIMAL_PRECISION; // When the Pool depletes to 0, so does each deposit
+            lastKUSDLossError_Offset = 0;
         } else {
-            uint256 kusdLossNumerator = _debtToOffset.mul(DECIMAL_PRECISION).sub(lastkusdLossError_Offset);
+            uint256 KUSDLossNumerator = _debtToOffset.mul(DECIMAL_PRECISION).sub(
+                lastKUSDLossError_Offset
+            );
             /*
-            * Add 1 to make error in quotient positive. We want "slightly too much" KUSD loss,
-            * which ensures the error in any given compoundedKUSDDeposit favors the Stability Pool.
-            */
-            kusdLossPerUnitStaked = (kusdLossNumerator.div(_totalKUSDDeposits)).add(1);
-            lastkusdLossError_Offset = (kusdLossPerUnitStaked.mul(_totalKUSDDeposits)).sub(kusdLossNumerator);
+             * Add 1 to make error in quotient positive. We want "slightly too much" KUSD loss,
+             * which ensures the error in any given compoundedKUSDDeposit favors the Stability Pool.
+             */
+            KUSDLossPerUnitStaked = (KUSDLossNumerator.div(_totalKUSDDeposits)).add(1);
+            lastKUSDLossError_Offset = (KUSDLossPerUnitStaked.mul(_totalKUSDDeposits)).sub(
+                KUSDLossNumerator
+            );
         }
 
         ETHGainPerUnitStaked = ETHNumerator.div(_totalKUSDDeposits);
         lastETHError_Offset = ETHNumerator.sub(ETHGainPerUnitStaked.mul(_totalKUSDDeposits));
 
-        return (ETHGainPerUnitStaked, kusdLossPerUnitStaked);
+        return (ETHGainPerUnitStaked, KUSDLossPerUnitStaked);
     }
 
     // Update the Stability Pool reward sum S and product P
-    function _updateRewardSumAndProduct(uint256 _ETHGainPerUnitStaked, uint256 _kusdLossPerUnitStaked) internal {
+    function _updateRewardSumAndProduct(
+        uint256 _ETHGainPerUnitStaked,
+        uint256 _KUSDLossPerUnitStaked
+    ) internal {
         uint256 currentP = P;
         uint256 newP;
 
-        assert(_kusdLossPerUnitStaked <= DECIMAL_PRECISION);
+        assert(_KUSDLossPerUnitStaked <= DECIMAL_PRECISION);
         /*
-        * The newProductFactor is the factor by which to change all deposits, due to the depletion of Stability Pool KUSD in the liquidation.
-        * We make the product factor 0 if there was a pool-emptying. Otherwise, it is (1 - kusdLossPerUnitStaked)
-        */
-        uint256 newProductFactor = uint256(DECIMAL_PRECISION).sub(_kusdLossPerUnitStaked);
+         * The newProductFactor is the factor by which to change all deposits, due to the depletion of Stability Pool KUSD in the liquidation.
+         * We make the product factor 0 if there was a pool-emptying. Otherwise, it is (1 - KUSDLossPerUnitStaked)
+         */
+        uint256 newProductFactor = uint256(DECIMAL_PRECISION).sub(_KUSDLossPerUnitStaked);
 
         uint128 currentScaleCached = currentScale;
         uint128 currentEpochCached = currentEpoch;
         uint256 currentS = epochToScaleToSum[currentEpochCached][currentScaleCached];
 
         /*
-        * Calculate the new S first, before we update P.
-        * The ETH gain for any given depositor from a liquidation depends on the value of their deposit
-        * (and the value of totalDeposits) prior to the Stability being depleted by the debt in the liquidation.
-        *
-        * Since S corresponds to ETH gain, and P to deposit loss, we update S first.
-        */
+         * Calculate the new S first, before we update P.
+         * The ETH gain for any given depositor from a liquidation depends on the value of their deposit
+         * (and the value of totalDeposits) prior to the Stability being depleted by the debt in the liquidation.
+         *
+         * Since S corresponds to ETH gain, and P to deposit loss, we update S first.
+         */
         uint256 marginalETHGain = _ETHGainPerUnitStaked.mul(currentP);
         uint256 newS = currentS.add(marginalETHGain);
         epochToScaleToSum[currentEpochCached][currentScaleCached] = newS;
@@ -607,9 +618,9 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
             emit ScaleUpdated(currentScale);
             newP = DECIMAL_PRECISION;
 
-        // If multiplying P by a non-zero product factor would reduce P below the scale boundary, increment the scale
+            // If multiplying P by a non-zero product factor would reduce P below the scale boundary, increment the scale
         } else if (currentP.mul(newProductFactor).div(DECIMAL_PRECISION) < SCALE_FACTOR) {
-            newP = currentP.mul(newProductFactor).mul(SCALE_FACTOR).div(DECIMAL_PRECISION); 
+            newP = currentP.mul(newProductFactor).mul(SCALE_FACTOR).div(DECIMAL_PRECISION);
             currentScale = currentScaleCached.add(1);
             emit ScaleUpdated(currentScale);
         } else {
@@ -643,100 +654,96 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
 
     // --- Reward calculator functions for depositor and front end ---
     function getDepositorAssetGain(address _depositor) public view override returns (uint256) {
-		uint256 initialDeposit = deposits[_depositor].initialValue;
+        uint256 initialDeposit = deposits[_depositor].initialValue;
 
-		if (initialDeposit == 0) {
-			return 0;
-		}
+        if (initialDeposit == 0) {
+            return 0;
+        }
 
-		Snapshots memory snapshots = depositSnapshots[_depositor];
+        Snapshots memory snapshots = depositSnapshots[_depositor];
 
-		return
-			SafetyTransfer.decimalsCorrection(
-				assetAddress,
-				_getAssetGainFromSnapshots(initialDeposit, snapshots)
-			);
-	}
+        return
+            SafetyTransfer.decimalsCorrection(
+                assetAddress,
+                _getAssetGainFromSnapshots(initialDeposit, snapshots)
+            );
+    }
 
-	function getDepositorAssetGain1e18(address _depositor) public view returns (uint256) {
-		uint256 initialDeposit = deposits[_depositor].initialValue;
-
-		if (initialDeposit == 0) {
-			return 0;
-		}
-
-		Snapshots memory snapshots = depositSnapshots[_depositor];
-
-		return _getAssetGainFromSnapshots(initialDeposit, snapshots);
-	}
-
-	function _getAssetGainFromSnapshots(uint256 initialDeposit, Snapshots memory snapshots)
-		internal
-		view
-		returns (uint256)
-	{
-		/*
-		 * Grab the sum 'S' from the epoch at which the stake was made. The ETH gain may span up to one scale change.
-		 * If it does, the second portion of the ETH gain is scaled by 1e9.
-		 * If the gain spans no scale change, the second portion will be 0.
-		 */
-		uint128 epochSnapshot = snapshots.epoch;
-		uint128 scaleSnapshot = snapshots.scale;
-		uint256 S_Snapshot = snapshots.S;
-		uint256 P_Snapshot = snapshots.P;
-
-		uint256 firstPortion = epochToScaleToSum[epochSnapshot][scaleSnapshot].sub(S_Snapshot);
-		uint256 secondPortion = epochToScaleToSum[epochSnapshot][scaleSnapshot.add(1)].div(
-			SCALE_FACTOR
-		);
-
-		uint256 AssetGain = initialDeposit
-			.mul(firstPortion.add(secondPortion))
-			.div(P_Snapshot)
-			.div(DECIMAL_PRECISION);
-
-		return AssetGain;
-	}
-
-
-    function _getETHGainFromSnapshots(uint256 initialDeposit, Snapshots memory snapshots) internal view returns (uint256) {
+    function _getAssetGainFromSnapshots(uint256 initialDeposit, Snapshots memory snapshots)
+        internal
+        view
+        returns (uint256)
+    {
         /*
-        * Grab the sum 'S' from the epoch at which the stake was made. The ETH gain may span up to one scale change.
-        * If it does, the second portion of the ETH gain is scaled by 1e9.
-        * If the gain spans no scale change, the second portion will be 0.
-        */
+         * Grab the sum 'S' from the epoch at which the stake was made. The ETH gain may span up to one scale change.
+         * If it does, the second portion of the ETH gain is scaled by 1e9.
+         * If the gain spans no scale change, the second portion will be 0.
+         */
         uint128 epochSnapshot = snapshots.epoch;
         uint128 scaleSnapshot = snapshots.scale;
         uint256 S_Snapshot = snapshots.S;
         uint256 P_Snapshot = snapshots.P;
 
         uint256 firstPortion = epochToScaleToSum[epochSnapshot][scaleSnapshot].sub(S_Snapshot);
-        uint256 secondPortion = epochToScaleToSum[epochSnapshot][scaleSnapshot.add(1)].div(SCALE_FACTOR);
+        uint256 secondPortion = epochToScaleToSum[epochSnapshot][scaleSnapshot.add(1)].div(
+            SCALE_FACTOR
+        );
 
-        uint256 ETHGain = initialDeposit.mul(firstPortion.add(secondPortion)).div(P_Snapshot).div(DECIMAL_PRECISION);
+        uint256 AssetGain = initialDeposit.mul(firstPortion.add(secondPortion)).div(P_Snapshot).div(
+            DECIMAL_PRECISION
+        );
+
+        return AssetGain;
+    }
+
+    function _getETHGainFromSnapshots(uint256 initialDeposit, Snapshots memory snapshots)
+        internal
+        view
+        returns (uint256)
+    {
+        /*
+         * Grab the sum 'S' from the epoch at which the stake was made. The ETH gain may span up to one scale change.
+         * If it does, the second portion of the ETH gain is scaled by 1e9.
+         * If the gain spans no scale change, the second portion will be 0.
+         */
+        uint128 epochSnapshot = snapshots.epoch;
+        uint128 scaleSnapshot = snapshots.scale;
+        uint256 S_Snapshot = snapshots.S;
+        uint256 P_Snapshot = snapshots.P;
+
+        uint256 firstPortion = epochToScaleToSum[epochSnapshot][scaleSnapshot].sub(S_Snapshot);
+        uint256 secondPortion = epochToScaleToSum[epochSnapshot][scaleSnapshot.add(1)].div(
+            SCALE_FACTOR
+        );
+
+        uint256 ETHGain = initialDeposit.mul(firstPortion.add(secondPortion)).div(P_Snapshot).div(
+            DECIMAL_PRECISION
+        );
 
         return ETHGain;
     }
 
     /*
-    * Calculate the KUMO gain earned by a deposit since its last snapshots were taken.
-    * Given by the formula:  KUMO = d0 * (G - G(0))/P(0)
-    * where G(0) and P(0) are the depositor's snapshots of the sum G and product P, respectively.
-    * d0 is the last recorded deposit value.
-    */
+     * Calculate the KUMO gain earned by a deposit since its last snapshots were taken.
+     * Given by the formula:  KUMO = d0 * (G - G(0))/P(0)
+     * where G(0) and P(0) are the depositor's snapshots of the sum G and product P, respectively.
+     * d0 is the last recorded deposit value.
+     */
     function getDepositorKUMOGain(address _depositor) public view override returns (uint256) {
         uint256 initialDeposit = deposits[_depositor].initialValue;
-        if (initialDeposit == 0) {return 0;}
+        if (initialDeposit == 0) {
+            return 0;
+        }
         Snapshots memory snapshots = depositSnapshots[_depositor];
-		return _getKUMOGainFromSnapshots(initialDeposit, snapshots);
+        return _getKUMOGainFromSnapshots(initialDeposit, snapshots);
 
         address frontEndTag = deposits[_depositor].frontEndTag;
 
         /*
-        * If not tagged with a front end, the depositor gets a 100% cut of what their deposit earned.
-        * Otherwise, their cut of the deposit's earnings is equal to the kickbackRate, set by the front end through
-        * which they made their deposit.
-        */
+         * If not tagged with a front end, the depositor gets a 100% cut of what their deposit earned.
+         * Otherwise, their cut of the deposit's earnings is equal to the kickbackRate, set by the front end through
+         * which they made their deposit.
+         */
         // uint256 kickbackRate = frontEndTag == address(0) ? DECIMAL_PRECISION : frontEnds[frontEndTag].kickbackRate;
 
         // Snapshots memory snapshots = depositSnapshots[_depositor];
@@ -747,112 +754,126 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
     }
 
     /*
-    * Return the KUMO gain earned by the front end. Given by the formula:  E = D0 * (G - G(0))/P(0)
-    * where G(0) and P(0) are the depositor's snapshots of the sum G and product P, respectively.
-    *
-    * D0 is the last recorded value of the front end's total tagged deposits.
-    */
+     * Return the KUMO gain earned by the front end. Given by the formula:  E = D0 * (G - G(0))/P(0)
+     * where G(0) and P(0) are the depositor's snapshots of the sum G and product P, respectively.
+     *
+     * D0 is the last recorded value of the front end's total tagged deposits.
+     */
     function getFrontEndKUMOGain(address _frontEnd) public view override returns (uint256) {
         uint256 frontEndStake = frontEndStakes[_frontEnd];
-        if (frontEndStake == 0) { return 0; }
+        if (frontEndStake == 0) {
+            return 0;
+        }
 
         uint256 kickbackRate = frontEnds[_frontEnd].kickbackRate;
         uint256 frontEndShare = uint256(DECIMAL_PRECISION).sub(kickbackRate);
 
         Snapshots memory snapshots = frontEndSnapshots[_frontEnd];
 
-        uint256 KUMOGain = frontEndShare.mul(_getKUMOGainFromSnapshots(frontEndStake, snapshots)).div(DECIMAL_PRECISION);
+        uint256 KUMOGain = frontEndShare
+            .mul(_getKUMOGainFromSnapshots(frontEndStake, snapshots))
+            .div(DECIMAL_PRECISION);
         return KUMOGain;
     }
 
-    function _getKUMOGainFromSnapshots(uint256 initialStake, Snapshots memory snapshots) internal view returns (uint256) {
-       /*
-        * Grab the sum 'G' from the epoch at which the stake was made. The KUMO gain may span up to one scale change.
-        * If it does, the second portion of the KUMO gain is scaled by 1e9.
-        * If the gain spans no scale change, the second portion will be 0.
-        */
+    function _getKUMOGainFromSnapshots(uint256 initialStake, Snapshots memory snapshots)
+        internal
+        view
+        returns (uint256)
+    {
+        /*
+         * Grab the sum 'G' from the epoch at which the stake was made. The KUMO gain may span up to one scale change.
+         * If it does, the second portion of the KUMO gain is scaled by 1e9.
+         * If the gain spans no scale change, the second portion will be 0.
+         */
         uint128 epochSnapshot = snapshots.epoch;
         uint128 scaleSnapshot = snapshots.scale;
         uint256 G_Snapshot = snapshots.G;
         uint256 P_Snapshot = snapshots.P;
 
         uint256 firstPortion = epochToScaleToG[epochSnapshot][scaleSnapshot].sub(G_Snapshot);
-        uint256 secondPortion = epochToScaleToG[epochSnapshot][scaleSnapshot.add(1)].div(SCALE_FACTOR);
+        uint256 secondPortion = epochToScaleToG[epochSnapshot][scaleSnapshot.add(1)].div(
+            SCALE_FACTOR
+        );
 
-        uint256 KUMOGain = initialStake.mul(firstPortion.add(secondPortion)).div(P_Snapshot).div(DECIMAL_PRECISION);
+        uint256 KUMOGain = initialStake.mul(firstPortion.add(secondPortion)).div(P_Snapshot).div(
+            DECIMAL_PRECISION
+        );
 
         return KUMOGain;
     }
 
     // --- Compounded deposit and compounded front end stake ---
-    	/*
-	 * Return the system's compounded stake. Given by the formula:  D = D0 * P/P(0)
-	 * where P(0) is the depositor's snapshot of the product P
-	 *
-	 * The system's compounded stake is equal to the sum of its depositors' compounded deposits.
-	 */
-	function getCompoundedTotalStake() public view override returns (uint256) {
-		uint256 cachedStake = totalStakes;
-		if (cachedStake == 0) {
-			return 0;
-		}
+    /*
+     * Return the system's compounded stake. Given by the formula:  D = D0 * P/P(0)
+     * where P(0) is the depositor's snapshot of the product P
+     *
+     * The system's compounded stake is equal to the sum of its depositors' compounded deposits.
+     */
+    function getCompoundedTotalStake() public view override returns (uint256) {
+        uint256 cachedStake = totalStakes;
+        if (cachedStake == 0) {
+            return 0;
+        }
 
-		return _getCompoundedStakeFromSnapshots(cachedStake, systemSnapshots);
-	}
+        return _getCompoundedStakeFromSnapshots(cachedStake, systemSnapshots);
+    }
 
-	// Internal function, used to calculcate compounded deposits and compounded stakes.
-	function _getCompoundedStakeFromSnapshots(uint256 initialStake, Snapshots memory snapshots)
-		internal
-		view
-		returns (uint256)
-	{
-		uint256 snapshot_P = snapshots.P;
-		uint128 scaleSnapshot = snapshots.scale;
-		uint128 epochSnapshot = snapshots.epoch;
+    // Internal function, used to calculcate compounded deposits and compounded stakes.
+    function _getCompoundedStakeFromSnapshots(uint256 initialStake, Snapshots memory snapshots)
+        internal
+        view
+        returns (uint256)
+    {
+        uint256 snapshot_P = snapshots.P;
+        uint128 scaleSnapshot = snapshots.scale;
+        uint128 epochSnapshot = snapshots.epoch;
 
-		// If stake was made before a pool-emptying event, then it has been fully cancelled with debt -- so, return 0
-		if (epochSnapshot < currentEpoch) {
-			return 0;
-		}
+        // If stake was made before a pool-emptying event, then it has been fully cancelled with debt -- so, return 0
+        if (epochSnapshot < currentEpoch) {
+            return 0;
+        }
 
-		uint256 compoundedStake;
-		uint128 scaleDiff = currentScale.sub(scaleSnapshot);
+        uint256 compoundedStake;
+        uint128 scaleDiff = currentScale.sub(scaleSnapshot);
 
-		/* Compute the compounded stake. If a scale change in P was made during the stake's lifetime,
-		 * account for it. If more than one scale change was made, then the stake has decreased by a factor of
-		 * at least 1e-9 -- so return 0.
-		 */
-		if (scaleDiff == 0) {
-			compoundedStake = initialStake.mul(P).div(snapshot_P);
-		} else if (scaleDiff == 1) {
-			compoundedStake = initialStake.mul(P).div(snapshot_P).div(SCALE_FACTOR);
-		} else {
-			compoundedStake = 0;
-		}
+        /* Compute the compounded stake. If a scale change in P was made during the stake's lifetime,
+         * account for it. If more than one scale change was made, then the stake has decreased by a factor of
+         * at least 1e-9 -- so return 0.
+         */
+        if (scaleDiff == 0) {
+            compoundedStake = initialStake.mul(P).div(snapshot_P);
+        } else if (scaleDiff == 1) {
+            compoundedStake = initialStake.mul(P).div(snapshot_P).div(SCALE_FACTOR);
+        } else {
+            compoundedStake = 0;
+        }
 
-		/*
-		 * If compounded deposit is less than a billionth of the initial deposit, return 0.
-		 *
-		 * NOTE: originally, this line was in place to stop rounding errors making the deposit too large. However, the error
-		 * corrections should ensure the error in P "favors the Pool", i.e. any given compounded deposit should slightly less
-		 * than it's theoretical value.
-		 *
-		 * Thus it's unclear whether this line is still really needed.
-		 */
-		if (compoundedStake < initialStake.div(1e9)) {
-			return 0;
-		}
+        /*
+         * If compounded deposit is less than a billionth of the initial deposit, return 0.
+         *
+         * NOTE: originally, this line was in place to stop rounding errors making the deposit too large. However, the error
+         * corrections should ensure the error in P "favors the Pool", i.e. any given compounded deposit should slightly less
+         * than it's theoretical value.
+         *
+         * Thus it's unclear whether this line is still really needed.
+         */
+        if (compoundedStake < initialStake.div(1e9)) {
+            return 0;
+        }
 
-		return compoundedStake;
-	}
+        return compoundedStake;
+    }
 
     /*
-    * Return the user's compounded deposit. Given by the formula:  d = d0 * P/P(0)
-    * where P(0) is the depositor's snapshot of the product P, taken when they last updated their deposit.
-    */
+     * Return the user's compounded deposit. Given by the formula:  d = d0 * P/P(0)
+     * where P(0) is the depositor's snapshot of the product P, taken when they last updated their deposit.
+     */
     function getCompoundedKUSDDeposit(address _depositor) public view override returns (uint256) {
         uint256 initialDeposit = deposits[_depositor].initialValue;
-        if (initialDeposit == 0) { return 0; }
+        if (initialDeposit == 0) {
+            return 0;
+        }
 
         Snapshots memory snapshots = depositSnapshots[_depositor];
 
@@ -861,15 +882,17 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
     }
 
     /*
-    * Return the front end's compounded stake. Given by the formula:  D = D0 * P/P(0)
-    * where P(0) is the depositor's snapshot of the product P, taken at the last time
-    * when one of the front end's tagged deposits updated their deposit.
-    *
-    * The front end's compounded stake is equal to the sum of its depositors' compounded deposits.
-    */
+     * Return the front end's compounded stake. Given by the formula:  D = D0 * P/P(0)
+     * where P(0) is the depositor's snapshot of the product P, taken at the last time
+     * when one of the front end's tagged deposits updated their deposit.
+     *
+     * The front end's compounded stake is equal to the sum of its depositors' compounded deposits.
+     */
     function getCompoundedFrontEndStake(address _frontEnd) public view override returns (uint256) {
         uint256 frontEndStake = frontEndStakes[_frontEnd];
-        if (frontEndStake == 0) { return 0; }
+        if (frontEndStake == 0) {
+            return 0;
+        }
 
         Snapshots memory snapshots = frontEndSnapshots[_frontEnd];
 
@@ -887,20 +910,11 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
         emit StabilityPoolKUSDBalanceUpdated(newtotalKUSDDeposits);
     }
 
-    function _sendETHGainToDepositor(uint256 _amount) internal {
-        if (_amount == 0) {return;}
-        uint256 newETH = assetBalance.sub(_amount);
-        assetBalance = newETH;
-        emit StabilityPoolAssetBalanceUpdated(newETH);
-        emit AssetSent(msg.sender, _amount);
-
-        (bool success, ) = msg.sender.call{ value: _amount }("");
-        require(success, "StabilityPool: sending ETH failed");
-    }
-
     // Send KUSD to user and decrease KUSD in Pool
     function _sendKUSDToDepositor(address _depositor, uint256 KUSDWithdrawal) internal {
-        if (KUSDWithdrawal == 0) {return;}
+        if (KUSDWithdrawal == 0) {
+            return;
+        }
 
         kusdToken.returnFromPool(address(this), _depositor, KUSDWithdrawal);
         _decreaseKUSD(KUSDWithdrawal);
@@ -926,7 +940,6 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
     //     deposits[_depositor].frontEndTag = _frontEndTag;
     //     emit FrontEndTagSet(_depositor, _frontEndTag);
     // }
-
 
     function _updateDepositAndSnapshots(address _depositor, uint256 _newValue) internal {
         deposits[_depositor].initialValue = _newValue;
@@ -982,69 +995,66 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
 
     // --- Sender functions for KUMO deposit, ETH gains and KUMOA gains ---
 
-	// Transfer the KUMO tokens from the user to the Stability Pool's address, and update its recorded KUMO
-	function _sendKUMOtoStabilityPool(address _address, uint256 _amount) internal {
-		kusdToken.sendToPool(_address, address(this), _amount);
-		uint256 newtotalKUSDDeposits = totalKUSDDeposits.add(_amount);
-		totalKUSDDeposits = newtotalKUSDDeposits;
-		emit StabilityPoolKUSDBalanceUpdated(newtotalKUSDDeposits);
-	}
+    // Transfer the KUMO tokens from the user to the Stability Pool's address, and update its recorded KUMO
+    function _sendKUMOtoStabilityPool(address _address, uint256 _amount) internal {
+        kusdToken.sendToPool(_address, address(this), _amount);
+        uint256 newtotalKUSDDeposits = totalKUSDDeposits.add(_amount);
+        totalKUSDDeposits = newtotalKUSDDeposits;
+        emit StabilityPoolKUSDBalanceUpdated(newtotalKUSDDeposits);
+    }
 
-	function _sendAssetGainToDepositor(uint256 _amount, uint256 _amountEther) internal {
-		if (_amount == 0) {
-			return;
-		}
+    function _sendAssetGainToDepositor(uint256 _amount) internal {
+        if (_amount == 0) {
+            return;
+        }
 
-		assetBalance = assetBalance.sub(_amountEther);
+        assetBalance = assetBalance.sub(_amount);
+        IERC20Upgradeable(assetAddress).safeTransfer(msg.sender, _amount);
 
-		if (assetAddress == ETH_REF_ADDRESS) {
-			(bool success, ) = msg.sender.call{ value: _amountEther }("");
-			require(success, "StabilityPool: sending ETH failed");
-		} else {
-			IERC20Upgradeable(assetAddress).safeTransfer(msg.sender, _amount);
-		}
+        emit StabilityPoolAssetBalanceUpdated(assetBalance);
+        emit AssetSent(msg.sender, _amount);
+    }
 
-		emit StabilityPoolAssetBalanceUpdated(assetBalance);
-		emit AssetSent(msg.sender, _amount);
-	}
+    // Send KUMO to user and decrease KUMO in Pool
+    function _sendKUMOToDepositor(address _depositor, uint256 KUSDWithdrawal) internal {
+        if (KUSDWithdrawal == 0) {
+            return;
+        }
 
-	// Send KUMO to user and decrease KUMO in Pool
-	function _sendKUMOToDepositor(address _depositor, uint256 KUSDWithdrawal) internal {
-		if (KUSDWithdrawal == 0) {
-			return;
-		}
+        kusdToken.returnFromPool(address(this), _depositor, KUSDWithdrawal);
+        _decreaseKUSD(KUSDWithdrawal);
+    }
 
-		kusdToken.returnFromPool(address(this), _depositor, KUSDWithdrawal);
-		_decreaseKUSD(KUSDWithdrawal);
-	}
+    // --- Stability Pool Deposit Functionality ---
 
-    	// --- Stability Pool Deposit Functionality ---
+    function _updateStakeAndSnapshots(uint256 _newValue) internal {
+        Snapshots storage snapshots = systemSnapshots;
+        totalStakes = _newValue;
 
+        uint128 currentScaleCached = currentScale;
+        uint128 currentEpochCached = currentEpoch;
+        uint256 currentP = P;
 
-	function _updateStakeAndSnapshots(uint256 _newValue) internal {
-		Snapshots storage snapshots = systemSnapshots;
-		totalStakes = _newValue;
+        // Get G for the current epoch and current scale
+        uint256 currentG = epochToScaleToG[currentEpochCached][currentScaleCached];
 
-		uint128 currentScaleCached = currentScale;
-		uint128 currentEpochCached = currentEpoch;
-		uint256 currentP = P;
+        // Record new snapshots of the latest running product P and sum G for the system
+        snapshots.P = currentP;
+        snapshots.G = currentG;
+        snapshots.scale = currentScaleCached;
+        snapshots.epoch = currentEpochCached;
 
-		// Get G for the current epoch and current scale
-		uint256 currentG = epochToScaleToG[currentEpochCached][currentScaleCached];
+        emit SystemSnapshotUpdated(currentP, currentG);
+    }
 
-		// Record new snapshots of the latest running product P and sum G for the system
-		snapshots.P = currentP;
-		snapshots.G = currentG;
-		snapshots.scale = currentScaleCached;
-		snapshots.epoch = currentEpochCached;
-
-		emit SystemSnapshotUpdated(currentP, currentG);
-	}
-
-    function _payOutKUMOGains(ICommunityIssuance _communityIssuance, address _depositor, address _frontEnd) internal {
+    function _payOutKUMOGains(
+        ICommunityIssuance _communityIssuance,
+        address _depositor,
+        address _frontEnd
+    ) internal {
         // Pay out front end's KUMO gain
         if (_frontEnd != address(0)) {
-            uint frontEndKUMOGain = getFrontEndKUMOGain(_frontEnd);
+            uint256 frontEndKUMOGain = getFrontEndKUMOGain(_frontEnd);
             _communityIssuance.sendKUMO(_frontEnd, frontEndKUMOGain);
             emit KUMOPaidToFrontEnd(_frontEnd, frontEndKUMOGain);
         }
@@ -1058,7 +1068,10 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
     // --- 'require' functions ---
 
     function _requireCallerIsActivePool() internal view {
-        require( msg.sender == address(kumoParams.activePool()), "StabilityPool: Caller is not ActivePool");
+        require(
+            msg.sender == address(kumoParams.activePool()),
+            "StabilityPool: Caller is not ActivePool"
+        );
     }
 
     function _requireCallerIsTroveManager() internal view {
@@ -1069,60 +1082,74 @@ contract StabilityPool is KumoBase, CheckContract, IStabilityPool {
         uint256 price = kumoParams.priceFeed().fetchPrice();
         address lowestTrove = sortedTroves.getLast(assetAddress);
         uint256 ICR = troveManager.getCurrentICR(assetAddress, lowestTrove, price);
-        require(ICR >= kumoParams.MCR(assetAddress), "StabilityPool: Cannot withdraw while there are troves with ICR < MCR");
+        require(
+            ICR >= kumoParams.MCR(assetAddress),
+            "StabilityPool: Cannot withdraw while there are troves with ICR < MCR"
+        );
     }
 
     function _requireUserHasDeposit(uint256 _initialDeposit) internal pure {
-        require(_initialDeposit > 0, 'StabilityPool: User must have a non-zero deposit');
+        require(_initialDeposit > 0, "StabilityPool: User must have a non-zero deposit");
     }
 
-     function _requireUserHasNoDeposit(address _address) internal view {
+    function _requireUserHasNoDeposit(address _address) internal view {
         uint256 initialDeposit = deposits[_address].initialValue;
-        require(initialDeposit == 0, 'StabilityPool: User must have no deposit');
+        require(initialDeposit == 0, "StabilityPool: User must have no deposit");
     }
 
     function _requireNonZeroAmount(uint256 _amount) internal pure {
-        require(_amount > 0, 'StabilityPool: Amount must be non-zero');
+        require(_amount > 0, "StabilityPool: Amount must be non-zero");
     }
 
     function _requireUserHasTrove(address _depositor) internal view {
-        require(troveManager.getTroveStatus(assetAddress, _depositor) == 1, "StabilityPool: caller must have an active trove to withdraw ETHGain to");
+        require(
+            troveManager.getTroveStatus(assetAddress, _depositor) == 1,
+            "StabilityPool: caller must have an active trove to withdraw Asset Gain to"
+        );
     }
 
-    function _requireUserHasETHGain(address _depositor) internal view {
-        uint256 ETHGain = getDepositorAssetGain( _depositor);
-        require(ETHGain > 0, "StabilityPool: caller must have non-zero ETH Gain");
+    function _requireUserHasAssetGain(address _depositor) internal view {
+        uint256 AssetGain = getDepositorAssetGain(_depositor);
+        require(AssetGain > 0, "StabilityPool: caller must have non-zero Asset Gain");
     }
 
     function _requireFrontEndNotRegistered(address _address) internal view {
-        require(!frontEnds[_address].registered, "StabilityPool: must not already be a registered front end");
+        require(
+            !frontEnds[_address].registered,
+            "StabilityPool: must not already be a registered front end"
+        );
     }
 
-     function _requireFrontEndIsRegisteredOrZero(address _address) internal view {
-        require(frontEnds[_address].registered || _address == address(0),
-            "StabilityPool: Tag must be a registered front end, or the zero address");
+    function _requireFrontEndIsRegisteredOrZero(address _address) internal view {
+        require(
+            frontEnds[_address].registered || _address == address(0),
+            "StabilityPool: Tag must be a registered front end, or the zero address"
+        );
     }
 
-    function  _requireValidKickbackRate(uint256 _kickbackRate) internal pure {
-        require (_kickbackRate <= DECIMAL_PRECISION, "StabilityPool: Kickback rate must be in range [0,1]");
+    function _requireValidKickbackRate(uint256 _kickbackRate) internal pure {
+        require(
+            _kickbackRate <= DECIMAL_PRECISION,
+            "StabilityPool: Kickback rate must be in range [0,1]"
+        );
     }
 
-	function receivedERC20(address _asset, uint256 _amount) external override {
-		_requireCallerIsActivePool();
+    function receivedERC20(address _asset, uint256 _amount) external override {
+        _requireCallerIsActivePool();
 
-		require(_asset == assetAddress, "Receiving the wrong asset in StabilityPool");
+        require(_asset == assetAddress, "Receiving the wrong asset in StabilityPool");
 
-		if (assetAddress != ETH_REF_ADDRESS) {
-			assetBalance = assetBalance.add(_amount);
-			emit StabilityPoolAssetBalanceUpdated(assetBalance);
-		}
-	}
+        if (assetAddress != ETH_REF_ADDRESS) {
+            assetBalance = assetBalance.add(_amount);
+            emit StabilityPoolAssetBalanceUpdated(assetBalance);
+        }
+    }
 
     // --- Fallback function ---
 
-	receive() external payable {
-		_requireCallerIsActivePool();
-		assetBalance = assetBalance.add(msg.value);
-		emit StabilityPoolAssetBalanceUpdated(assetBalance);
-	}
+    receive() external payable {
+        _requireCallerIsActivePool();
+        assetBalance = assetBalance.add(msg.value);
+        emit StabilityPoolAssetBalanceUpdated(assetBalance);
+    }
 }

--- a/packages/contracts/test/TroveManagerTest.js
+++ b/packages/contracts/test/TroveManagerTest.js
@@ -140,7 +140,7 @@ contract('TroveManager', async accounts => {
     await troveManager.liquidate(assetAddress1, alice, { from: owner });
 
     // check the Trove is successfully closed, and removed from sortedList
-    const status = (await troveManager.Troves(alice, assetAddress1))[4]
+    const status = (await troveManager.Troves(alice, assetAddress1))[TroveData.status]
     assert.equal(status, 3)  // status enum 3 corresponds to "Closed by liquidation"
     const alice_Trove_isInSortedList_Asset1 = await sortedTroves.contains(assetAddress1, alice)
     assert.isFalse(alice_Trove_isInSortedList_Asset1)
@@ -4273,9 +4273,6 @@ contract('TroveManager', async accounts => {
       )
 
       await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
-      // await borrowerOperations.adjustTrove(th._100pct, 0, kusdAmount, true, alice, alice, { from: alice, value: kusdAmount.mul(mv._1e18BN).div(price) })
-      console.log("kusdAmount: ", kusdAmount.toString())
-      console.log("value:      ", kusdAmount.mul(mv._1e18BN).div(price).toString())
       await borrowerOperations.adjustTrove(assetAddress1, kusdAmount.mul(mv._1e18BN).div(price), th._100pct, 0, kusdAmount, true, alice, alice, { from: alice })
 
     }

--- a/packages/contracts/test/TroveManager_RecoveryModeTest.js
+++ b/packages/contracts/test/TroveManager_RecoveryModeTest.js
@@ -7,6 +7,7 @@ const toBN = th.toBN
 const assertRevert = th.assertRevert
 const mv = testHelpers.MoneyValues
 const timeValues = testHelpers.TimeValues
+const TroveData = testHelpers.TroveData
 
 const TroveManagerTester = artifacts.require("./TroveManagerTester")
 const KUSDToken = artifacts.require("./KUSDToken.sol")
@@ -35,7 +36,7 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     whale, defaulter_1, defaulter_2, defaulter_3, defaulter_4,
     A, B, C, D, E, F, G, H, I] = accounts;
 
-    const [bountyAddress, lpRewardsAddress, multisig] = accounts.slice(997, 1000)
+  const [bountyAddress, lpRewardsAddress, multisig] = accounts.slice(997, 1000)
 
   let priceFeed
   let kusdToken
@@ -47,11 +48,15 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   let functionCaller
   let borrowerOperations
   let collSurplusPool
+  let kumoParams
+  let KUMOContracts
+  let hardhatTester
+  let erc20Asset1
 
   let contracts
 
-  const getOpenTroveKUSDAmount = async (totalDebt) => th.getOpenTroveKUSDAmount(contracts, totalDebt)
-  const getNetBorrowingAmount = async (debtWithFee) => th.getNetBorrowingAmount(contracts, debtWithFee)
+  const getOpenTroveKUSDAmount = async (totalDebt, asset) => th.getOpenTroveKUSDAmount(contracts, totalDebt, asset)
+  const getNetBorrowingAmount = async (debtWithFee, asset) => th.getNetBorrowingAmount(contracts, debtWithFee, asset)
   const openTrove = async (params) => th.openTrove(contracts, params)
 
   beforeEach(async () => {
@@ -62,7 +67,8 @@ contract('TroveManager - in Recovery Mode', async accounts => {
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address
     )
-    const KUMOContracts = await deploymentHelper.deployKUMOContracts(bountyAddress, lpRewardsAddress, multisig)
+    KUMOContracts = await deploymentHelper.deployKUMOContracts(bountyAddress, lpRewardsAddress, multisig)
+    hardhatTester = await deploymentHelper.deployTesterContractsHardhat()
 
     priceFeed = contracts.priceFeedTestnet
     kusdToken = contracts.kusdToken
@@ -74,22 +80,40 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     functionCaller = contracts.functionCaller
     borrowerOperations = contracts.borrowerOperations
     collSurplusPool = contracts.collSurplusPool
+    kumoParams = contracts.kumoParameters
+
+    erc20Asset1 = hardhatTester.erc20
+    assetAddress1 = erc20Asset1.address
 
     await deploymentHelper.connectKUMOContracts(KUMOContracts)
     await deploymentHelper.connectCoreContracts(contracts, KUMOContracts)
     await deploymentHelper.connectKUMOContractsToCore(KUMOContracts, contracts)
+
+    // Add asset to the system
+    await deploymentHelper.addNewAssetToSystem(contracts, KUMOContracts, assetAddress1)
+
+    // Mint token to each acccount
+    let index = 0;
+    for (const acc of accounts) {
+      // await vstaToken.approve(vstaStaking.address, await erc20Asset1.balanceOf(acc), { from: acc })
+      await erc20Asset1.mint(acc, await web3.eth.getBalance(acc))
+      index++;
+
+      if (index >= 25)
+        break;
+    }
   })
 
   it("checkRecoveryMode(): Returns true if TCR falls below CCR", async () => {
     // --- SETUP ---
     //  Alice and Bob withdraw such that the TCR is ~150%
-    await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
 
-    const TCR = (await th.getTCR(contracts)).toString()
+    const TCR = (await th.getTCR(contracts, assetAddress1)).toString()
     assert.equal(TCR, dec(15, 17))
 
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts);
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1);
     assert.isFalse(recoveryMode_Before)
 
     // --- TEST ---
@@ -100,16 +124,16 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // const price = await priceFeed.getPrice()
     // await troveManager.checkTCRAndSetRecoveryMode(price)
 
-    const recoveryMode_After = await th.checkRecoveryMode(contracts);
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1);
     assert.isTrue(recoveryMode_After)
   })
 
   it("checkRecoveryMode(): Returns true if TCR stays less than CCR", async () => {
     // --- SETUP ---
-    await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
 
-    const TCR = (await th.getTCR(contracts)).toString()
+    const TCR = (await th.getTCR(contracts, assetAddress1)).toString()
     assert.equal(TCR, '1500000000000000000')
 
     // --- TEST ---
@@ -117,48 +141,48 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:150KUSD, reducing TCR below 150%
     await priceFeed.setPrice('150000000000000000000')
 
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts);
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1);
     assert.isTrue(recoveryMode_Before)
 
-    await borrowerOperations.addColl(alice, alice, { from: alice, value: '1' })
+    await borrowerOperations.addColl(assetAddress1, toBN(1), alice, alice, { from: alice })
 
-    const recoveryMode_After = await th.checkRecoveryMode(contracts);
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1);
     assert.isTrue(recoveryMode_After)
   })
 
   it("checkRecoveryMode(): returns false if TCR stays above CCR", async () => {
     // --- SETUP ---
-    await openTrove({ ICR: toBN(dec(450, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(450, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
 
     // --- TEST ---
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts);
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1);
     assert.isFalse(recoveryMode_Before)
 
-    await borrowerOperations.withdrawColl(_1_Ether, alice, alice, { from: alice })
+    await borrowerOperations.withdrawColl(assetAddress1, _1_Ether, alice, alice, { from: alice })
 
-    const recoveryMode_After = await th.checkRecoveryMode(contracts);
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1);
     assert.isFalse(recoveryMode_After)
   })
 
   it("checkRecoveryMode(): returns false if TCR rises above CCR", async () => {
     // --- SETUP ---
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
 
-    const TCR = (await th.getTCR(contracts)).toString()
+    const TCR = (await th.getTCR(contracts, assetAddress1)).toString()
     assert.equal(TCR, '1500000000000000000')
 
     // --- TEST ---
     // price drops to 1ETH:150KUSD, reducing TCR below 150%
     await priceFeed.setPrice('150000000000000000000')
 
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts);
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1);
     assert.isTrue(recoveryMode_Before)
 
-    await borrowerOperations.addColl(alice, alice, { from: alice, value: A_coll })
+    await borrowerOperations.addColl(assetAddress1, A_coll, alice, alice, { from: alice })
 
-    const recoveryMode_After = await th.checkRecoveryMode(contracts);
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1);
     assert.isFalse(recoveryMode_After)
   })
 
@@ -167,15 +191,15 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   it("liquidate(), with ICR < 100%: removes stake and updates totalStakes", async () => {
     // --- SETUP ---
     //  Alice and Bob withdraw such that the TCR is ~150%
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
 
-    const TCR = (await th.getTCR(contracts)).toString()
+    const TCR = (await th.getTCR(contracts, assetAddress1)).toString()
     assert.equal(TCR, '1500000000000000000')
 
 
-    const bob_Stake_Before = (await troveManager.Troves(bob))[2]
-    const totalStakes_Before = await troveManager.totalStakes()
+    const bob_Stake_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const totalStakes_Before = await troveManager.totalStakes(assetAddress1)
 
     assert.equal(bob_Stake_Before.toString(), B_coll)
     assert.equal(totalStakes_Before.toString(), A_coll.add(B_coll))
@@ -185,18 +209,18 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // check Bob's ICR falls to 75%
-    const bob_ICR = await troveManager.getCurrentICR(bob, price);
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price);
     assert.equal(bob_ICR, '750000000000000000')
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
-    const bob_Stake_After = (await troveManager.Troves(bob))[2]
-    const totalStakes_After = await troveManager.totalStakes()
+    const bob_Stake_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const totalStakes_After = await troveManager.totalStakes(assetAddress1)
 
     assert.equal(bob_Stake_After, 0)
     assert.equal(totalStakes_After.toString(), A_coll)
@@ -205,37 +229,37 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   it("liquidate(), with ICR < 100%: updates system snapshots correctly", async () => {
     // --- SETUP ---
     //  Alice, Bob and Dennis withdraw such that their ICRs and the TCR is ~150%
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: dennis } })
 
-    const TCR = (await th.getTCR(contracts)).toString()
+    const TCR = (await th.getTCR(contracts, assetAddress1)).toString()
     assert.equal(TCR, '1500000000000000000')
 
     // --- TEST ---
     // price drops to 1ETH:100KUSD, reducing TCR below 150%, and all Troves below 100% ICR
     await priceFeed.setPrice('100000000000000000000')
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Dennis is liquidated
-    await troveManager.liquidate(dennis, { from: owner })
+    await troveManager.liquidate(assetAddress1, dennis, { from: owner })
 
-    const totalStakesSnaphot_before = (await troveManager.totalStakesSnapshot()).toString()
-    const totalCollateralSnapshot_before = (await troveManager.totalCollateralSnapshot()).toString()
+    const totalStakesSnaphot_before = (await troveManager.totalStakesSnapshot(assetAddress1)).toString()
+    const totalCollateralSnapshot_before = (await troveManager.totalCollateralSnapshot(assetAddress1)).toString()
 
     assert.equal(totalStakesSnaphot_before, A_coll.add(B_coll))
     assert.equal(totalCollateralSnapshot_before, A_coll.add(B_coll).add(th.applyLiquidationFee(D_coll))) // 6 + 3*0.995
 
-    const A_reward  = th.applyLiquidationFee(D_coll).mul(A_coll).div(A_coll.add(B_coll))
-    const B_reward  = th.applyLiquidationFee(D_coll).mul(B_coll).div(A_coll.add(B_coll))
+    const A_reward = th.applyLiquidationFee(D_coll).mul(A_coll).div(A_coll.add(B_coll))
+    const B_reward = th.applyLiquidationFee(D_coll).mul(B_coll).div(A_coll.add(B_coll))
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
-    const totalStakesSnaphot_After = (await troveManager.totalStakesSnapshot())
-    const totalCollateralSnapshot_After = (await troveManager.totalCollateralSnapshot())
+    const totalStakesSnaphot_After = (await troveManager.totalStakesSnapshot(assetAddress1))
+    const totalCollateralSnapshot_After = (await troveManager.totalCollateralSnapshot(assetAddress1))
 
     assert.equal(totalStakesSnaphot_After.toString(), A_coll)
     // total collateral should always be 9 minus gas compensations, as all liquidations in this test case are full redistributions
@@ -245,14 +269,14 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   it("liquidate(), with ICR < 100%: closes the Trove and removes it from the Trove array", async () => {
     // --- SETUP ---
     //  Alice and Bob withdraw such that the TCR is ~150%
-    await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(150, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
 
-    const TCR = (await th.getTCR(contracts)).toString()
+    const TCR = (await th.getTCR(contracts, assetAddress1)).toString()
     assert.equal(TCR, '1500000000000000000')
 
-    const bob_TroveStatus_Before = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(bob)
+    const bob_TroveStatus_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(assetAddress1, bob)
 
     assert.equal(bob_TroveStatus_Before, 1) // status enum element 1 corresponds to "Active"
     assert.isTrue(bob_Trove_isInSortedList_Before)
@@ -262,19 +286,19 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // check Bob's ICR falls to 75%
-    const bob_ICR = await troveManager.getCurrentICR(bob, price);
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price);
     assert.equal(bob_ICR, '750000000000000000')
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     // check Bob's Trove is successfully closed, and removed from sortedList
-    const bob_TroveStatus_After = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_After = await sortedTroves.contains(bob)
+    const bob_TroveStatus_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_After = await sortedTroves.contains(assetAddress1, bob)
     assert.equal(bob_TroveStatus_After, 3)  // status enum element 3 corresponds to "Closed by liquidation"
     assert.isFalse(bob_Trove_isInSortedList_After)
   })
@@ -283,9 +307,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     //  Alice, Bob and Dennis withdraw such that their ICRs and the TCR is ~150%
     const spDeposit = toBN(dec(390, 18))
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: dennis } })
 
     // Alice deposits to SP
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: alice })
@@ -295,18 +319,18 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     assert.equal(P_Before, '1000000000000000000')
 
-    // const TCR = (await th.getTCR(contracts)).toString()
+    // const TCR = (await th.getTCR(contracts, assetAddress1)).toString()
     // assert.equal(TCR, '1500000000000000000')
 
     // --- TEST ---
     // price drops to 1ETH:100KUSD, reducing TCR below 150%, and all Troves below 100% ICR
     await priceFeed.setPrice('100000000000000000000')
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // liquidate bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     // check SP rewards-per-unit-staked after liquidation - should be no increase
     const P_After = (await stabilityPool.P()).toString()
@@ -319,16 +343,16 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   it("liquidate(), with 100 < ICR < 110%: removes stake and updates totalStakes", async () => {
     // --- SETUP ---
     //  Bob withdraws up to 2000 KUSD of debt, bringing his ICR to 210%
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
 
     let price = await priceFeed.getPrice()
     // Total TCR = 24*200/2050 = 234%
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
     assert.isAtMost(th.getDifference(TCR, A_coll.add(B_coll).mul(price).div(A_totalDebt.add(B_totalDebt))), 1000)
 
-    const bob_Stake_Before = (await troveManager.Troves(bob))[2]
-    const totalStakes_Before = await troveManager.totalStakes()
+    const bob_Stake_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const totalStakes_Before = await troveManager.totalStakes(assetAddress1)
 
     assert.equal(bob_Stake_Before.toString(), B_coll)
     assert.equal(totalStakes_Before.toString(), A_coll.add(B_coll))
@@ -338,18 +362,18 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('100000000000000000000')
     price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // check Bob's ICR falls to 105%
-    const bob_ICR = await troveManager.getCurrentICR(bob, price);
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price);
     assert.equal(bob_ICR, '1050000000000000000')
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
-    const bob_Stake_After = (await troveManager.Troves(bob))[2]
-    const totalStakes_After = await troveManager.totalStakes()
+    const bob_Stake_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const totalStakes_After = await troveManager.totalStakes(assetAddress1)
 
     assert.equal(bob_Stake_After, 0)
     assert.equal(totalStakes_After.toString(), A_coll)
@@ -359,12 +383,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     //  Alice and Dennis withdraw such that their ICR is ~150%
     //  Bob withdraws up to 20000 KUSD of debt, bringing his ICR to 210%
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraKUSDAmount: dec(20000, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: dennis } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraKUSDAmount: dec(20000, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: dennis } })
 
-    const totalStakesSnaphot_1 = (await troveManager.totalStakesSnapshot()).toString()
-    const totalCollateralSnapshot_1 = (await troveManager.totalCollateralSnapshot()).toString()
+    const totalStakesSnaphot_1 = (await troveManager.totalStakesSnapshot(assetAddress1)).toString()
+    const totalCollateralSnapshot_1 = (await troveManager.totalCollateralSnapshot(assetAddress1)).toString()
     assert.equal(totalStakesSnaphot_1, 0)
     assert.equal(totalCollateralSnapshot_1, 0)
 
@@ -373,14 +397,14 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Dennis is liquidated
-    await troveManager.liquidate(dennis, { from: owner })
+    await troveManager.liquidate(assetAddress1, dennis, { from: owner })
 
-    const A_reward  = th.applyLiquidationFee(D_coll).mul(A_coll).div(A_coll.add(B_coll))
-    const B_reward  = th.applyLiquidationFee(D_coll).mul(B_coll).div(A_coll.add(B_coll))
+    const A_reward = th.applyLiquidationFee(D_coll).mul(A_coll).div(A_coll.add(B_coll))
+    const B_reward = th.applyLiquidationFee(D_coll).mul(B_coll).div(A_coll.add(B_coll))
 
     /*
     Prior to Dennis liquidation, total stakes and total collateral were each 27 ether. 
@@ -388,8 +412,8 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Check snapshots. Dennis' liquidated collateral is distributed and remains in the system. His 
     stake is removed, leaving 24+3*0.995 ether total collateral, and 24 ether total stakes. */
 
-    const totalStakesSnaphot_2 = (await troveManager.totalStakesSnapshot()).toString()
-    const totalCollateralSnapshot_2 = (await troveManager.totalCollateralSnapshot()).toString()
+    const totalStakesSnaphot_2 = (await troveManager.totalStakesSnapshot(assetAddress1)).toString()
+    const totalCollateralSnapshot_2 = (await troveManager.totalCollateralSnapshot(assetAddress1)).toString()
     assert.equal(totalStakesSnaphot_2, A_coll.add(B_coll))
     assert.equal(totalCollateralSnapshot_2, A_coll.add(B_coll).add(th.applyLiquidationFee(D_coll))) // 24 + 3*0.995
 
@@ -397,18 +421,18 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const _110percent = web3.utils.toBN('1100000000000000000')
     const _100percent = web3.utils.toBN('1000000000000000000')
 
-    const bob_ICR = (await troveManager.getCurrentICR(bob, price))
+    const bob_ICR = (await troveManager.getCurrentICR(assetAddress1, bob, price))
 
     assert.isTrue(bob_ICR.lt(_110percent))
     assert.isTrue(bob_ICR.gt(_100percent))
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     /* After Bob's liquidation, Bob's stake (21 ether) should be removed from total stakes, 
     but his collateral should remain in the system (*0.995). */
-    const totalStakesSnaphot_3 = (await troveManager.totalStakesSnapshot())
-    const totalCollateralSnapshot_3 = (await troveManager.totalCollateralSnapshot())
+    const totalStakesSnaphot_3 = (await troveManager.totalStakesSnapshot(assetAddress1))
+    const totalCollateralSnapshot_3 = (await troveManager.totalCollateralSnapshot(assetAddress1))
     assert.equal(totalStakesSnaphot_3.toString(), A_coll)
     // total collateral should always be 27 minus gas compensations, as all liquidations in this test case are full redistributions
     assert.isAtMost(th.getDifference(totalCollateralSnapshot_3.toString(), A_coll.add(A_reward).add(th.applyLiquidationFee(B_coll.add(B_reward)))), 1000)
@@ -417,11 +441,11 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   it("liquidate(), with 100% < ICR < 110%: closes the Trove and removes it from the Trove array", async () => {
     // --- SETUP ---
     //  Bob withdraws up to 2000 KUSD of debt, bringing his ICR to 210%
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
 
-    const bob_TroveStatus_Before = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(bob)
+    const bob_TroveStatus_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(assetAddress1, bob)
 
     assert.equal(bob_TroveStatus_Before, 1) // status enum element 1 corresponds to "Active"
     assert.isTrue(bob_Trove_isInSortedList_Before)
@@ -432,19 +456,19 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const price = await priceFeed.getPrice()
 
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // check Bob's ICR has fallen to 105%
-    const bob_ICR = await troveManager.getCurrentICR(bob, price);
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price);
     assert.equal(bob_ICR, '1050000000000000000')
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     // check Bob's Trove is successfully closed, and removed from sortedList
-    const bob_TroveStatus_After = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_After = await sortedTroves.contains(bob)
+    const bob_TroveStatus_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_After = await sortedTroves.contains(assetAddress1, bob)
     assert.equal(bob_TroveStatus_After, 3)  // status enum element 3 corresponds to "Closed by liquidation"
     assert.isFalse(bob_Trove_isInSortedList_After)
   })
@@ -454,9 +478,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     //  Alice and Dennis withdraw such that their ICR is ~150%
     //  Bob withdraws up to 2000 KUSD of debt, bringing his ICR to 210%
     const spDeposit = toBN(dec(390, 18))
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraParams: { from: dennis } })
 
     // Alice deposits 390KUSD to the Stability Pool
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: alice })
@@ -466,11 +490,11 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // check Bob's ICR has fallen to 105%
-    const bob_ICR = await troveManager.getCurrentICR(bob, price);
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price);
     assert.equal(bob_ICR, '1050000000000000000')
 
     // check pool KUSD before liquidation
@@ -493,10 +517,10 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     After offsetting 390 KUSD and 4.074525 ether, the remainders - 1610 KUSD and 16.820475 ether - should be redistributed to all active Troves.
    */
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     const aliceDeposit = await stabilityPool.getCompoundedKUSDDeposit(alice)
-    const aliceETHGain = await stabilityPool.getDepositorETHGain(alice)
+    const aliceETHGain = await stabilityPool.getDepositorAssetGain(alice)
     const aliceExpectedETHGain = spDeposit.mul(th.applyLiquidationFee(B_coll)).div(B_totalDebt)
 
     assert.equal(aliceDeposit.toString(), 0)
@@ -511,8 +535,8 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     L_KUSDDebt = 1610 / 6 = 268.333 KUSD
     L_ETH = 16.820475 /6 =  2.8034125 ether
     */
-    const L_KUSDDebt = (await troveManager.L_KUSDDebt()).toString()
-    const L_ETH = (await troveManager.L_ETH()).toString()
+    const L_KUSDDebt = (await troveManager.L_KUSDDebts(assetAddress1)).toString()
+    const L_ETH = (await troveManager.L_ASSETS(assetAddress1)).toString()
 
     assert.isAtMost(th.getDifference(L_KUSDDebt, B_totalDebt.sub(spDeposit).mul(mv._1e18BN).div(A_coll.add(D_coll))), 100)
     assert.isAtMost(th.getDifference(L_ETH, th.applyLiquidationFee(B_coll.sub(B_coll.mul(spDeposit).div(B_totalDebt)).mul(mv._1e18BN).div(A_coll.add(D_coll)))), 100)
@@ -524,29 +548,29 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice and Dennis withdraw, resulting in ICRs of 266%. 
     // Bob withdraws, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // --- TEST ---
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check Bob's ICR is >110% but still lowest
-    const bob_ICR = (await troveManager.getCurrentICR(bob, price)).toString()
-    const alice_ICR = (await troveManager.getCurrentICR(alice, price)).toString()
-    const dennis_ICR = (await troveManager.getCurrentICR(dennis, price)).toString()
+    const bob_ICR = (await troveManager.getCurrentICR(assetAddress1, bob, price)).toString()
+    const alice_ICR = (await troveManager.getCurrentICR(assetAddress1, alice, price)).toString()
+    const dennis_ICR = (await troveManager.getCurrentICR(assetAddress1, dennis, price)).toString()
     assert.equal(bob_ICR, '1200000000000000000')
     assert.equal(alice_ICR, dec(133, 16))
     assert.equal(dennis_ICR, dec(133, 16))
 
-    // console.log(`TCR: ${await th.getTCR(contracts)}`)
+    // console.log(`TCR: ${await th.getTCR(contracts, assetAddress1)}`)
     // Try to liquidate Bob
-    await assertRevert(troveManager.liquidate(bob, { from: owner }), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, bob, { from: owner }), "TroveManager: nothing to liquidate")
 
     // Check that Pool rewards don't change
     const P_Before = (await stabilityPool.P()).toString()
@@ -554,19 +578,19 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.equal(P_Before, '1000000000000000000')
 
     // Check that redistribution rewards don't change
-    const L_KUSDDebt = (await troveManager.L_KUSDDebt()).toString()
-    const L_ETH = (await troveManager.L_ETH()).toString()
+    const L_KUSDDebt = (await troveManager.L_KUSDDebts(assetAddress1)).toString()
+    const L_ETH = (await troveManager.L_ASSETS(assetAddress1)).toString()
 
     assert.equal(L_KUSDDebt, '0')
     assert.equal(L_ETH, '0')
 
     // Check that Bob's Trove and stake remains active with unchanged coll and debt
-    const bob_Trove = await troveManager.Troves(bob);
-    const bob_Debt = bob_Trove[0].toString()
-    const bob_Coll = bob_Trove[1].toString()
-    const bob_Stake = bob_Trove[2].toString()
-    const bob_TroveStatus = bob_Trove[3].toString()
-    const bob_isInSortedTrovesList = await sortedTroves.contains(bob)
+    const bob_Trove = await troveManager.Troves(bob, assetAddress1);
+    const bob_Debt = bob_Trove[TroveData.debt].toString()
+    const bob_Coll = bob_Trove[TroveData.coll].toString()
+    const bob_Stake = bob_Trove[TroveData.stake].toString()
+    const bob_TroveStatus = bob_Trove[TroveData.status].toString()
+    const bob_isInSortedTrovesList = await sortedTroves.contains(assetAddress1, bob)
 
     th.assertIsApproximatelyEqual(bob_Debt.toString(), B_totalDebt)
     assert.equal(bob_Coll.toString(), B_coll)
@@ -581,9 +605,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits KUSD in the Stability Pool
     const spDeposit = B_totalDebt.add(toBN(1))
@@ -593,17 +617,17 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check Bob's ICR is between 110 and TCR
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
     assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(TCR))
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     /* Check accrued Stability Pool rewards after. Total Pool deposits was 1490 KUSD, Alice sole depositor.
     As liquidated debt (250 KUSD) was completely offset
@@ -613,29 +637,28 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   
     */
     const aliceExpectedDeposit = await stabilityPool.getCompoundedKUSDDeposit(alice)
-    const aliceExpectedETHGain = await stabilityPool.getDepositorETHGain(alice)
+    const aliceExpectedETHGain = await stabilityPool.getDepositorAssetGain(alice)
 
     assert.isAtMost(th.getDifference(aliceExpectedDeposit.toString(), spDeposit.sub(B_totalDebt)), 2000)
     assert.isAtMost(th.getDifference(aliceExpectedETHGain, th.applyLiquidationFee(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))), 3000)
 
     // check Bob’s collateral surplus
     const bob_remainingCollateral = B_coll.sub(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_remainingCollateral)
     // can claim collateral
-    const bob_balanceBefore = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_expectedBalance = bob_balanceBefore.sub(th.toBN(BOB_GAS * GAS_PRICE))
-    const bob_balanceAfter = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_expectedBalance.add(th.toBN(bob_remainingCollateral)))
+    const bob_balanceBefore = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral)))
   })
 
-   it("liquidate(), with ICR% = 110 < TCR, and StabilityPool KUSD > debt to liquidate: offsets the trove entirely with the pool, there’s no collateral surplus", async () => {
+  it("liquidate(), with ICR% = 110 < TCR, and StabilityPool KUSD > debt to liquidate: offsets the trove entirely with the pool, there’s no collateral surplus", async () => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 220%. Bob has lowest ICR.
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits KUSD in the Stability Pool
     const spDeposit = B_totalDebt.add(toBN(1))
@@ -645,17 +668,17 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check Bob's ICR = 110
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
     assert.isTrue(bob_ICR.eq(mv._MCR))
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     /* Check accrued Stability Pool rewards after. Total Pool deposits was 1490 KUSD, Alice sole depositor.
     As liquidated debt (250 KUSD) was completely offset
@@ -665,22 +688,22 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     */
     const aliceExpectedDeposit = await stabilityPool.getCompoundedKUSDDeposit(alice)
-    const aliceExpectedETHGain = await stabilityPool.getDepositorETHGain(alice)
+    const aliceExpectedETHGain = await stabilityPool.getDepositorAssetGain(alice)
 
     assert.isAtMost(th.getDifference(aliceExpectedDeposit.toString(), spDeposit.sub(B_totalDebt)), 2000)
     assert.isAtMost(th.getDifference(aliceExpectedETHGain, th.applyLiquidationFee(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))), 3000)
 
     // check Bob’s collateral surplus
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), '0')
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), '0')
   })
 
   it("liquidate(), with  110% < ICR < TCR, and StabilityPool KUSD > debt to liquidate: removes stake and updates totalStakes", async () => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits KUSD in the Stability Pool
     await stabilityPool.provideToSP(B_totalDebt.add(toBN(1)), ZERO_ADDRESS, { from: alice })
@@ -690,48 +713,47 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // check stake and totalStakes before
-    const bob_Stake_Before = (await troveManager.Troves(bob))[2]
-    const totalStakes_Before = await troveManager.totalStakes()
+    const bob_Stake_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const totalStakes_Before = await troveManager.totalStakes(assetAddress1)
 
     assert.equal(bob_Stake_Before.toString(), B_coll)
     assert.equal(totalStakes_Before.toString(), A_coll.add(B_coll).add(D_coll))
 
     // Check Bob's ICR is between 110 and 150
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
-    assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(await th.getTCR(contracts)))
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(await th.getTCR(contracts, assetAddress1)))
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     // check stake and totalStakes after
-    const bob_Stake_After = (await troveManager.Troves(bob))[2]
-    const totalStakes_After = await troveManager.totalStakes()
+    const bob_Stake_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const totalStakes_After = await troveManager.totalStakes(assetAddress1)
 
     assert.equal(bob_Stake_After, 0)
     assert.equal(totalStakes_After.toString(), A_coll.add(D_coll))
 
     // check Bob’s collateral surplus
     const bob_remainingCollateral = B_coll.sub(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_remainingCollateral)
     // can claim collateral
-    const bob_balanceBefore = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_expectedBalance = bob_balanceBefore.sub(th.toBN(BOB_GAS * GAS_PRICE))
-    const bob_balanceAfter = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_expectedBalance.add(th.toBN(bob_remainingCollateral)))
+    const bob_balanceBefore = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral)))
   })
 
   it("liquidate(), with  110% < ICR < TCR, and StabilityPool KUSD > debt to liquidate: updates system snapshots", async () => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits KUSD in the Stability Pool
     await stabilityPool.provideToSP(B_totalDebt.add(toBN(1)), ZERO_ADDRESS, { from: alice })
@@ -741,25 +763,25 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // check system snapshots before
-    const totalStakesSnaphot_before = (await troveManager.totalStakesSnapshot()).toString()
-    const totalCollateralSnapshot_before = (await troveManager.totalCollateralSnapshot()).toString()
+    const totalStakesSnaphot_before = (await troveManager.totalStakesSnapshot(assetAddress1)).toString()
+    const totalCollateralSnapshot_before = (await troveManager.totalCollateralSnapshot(assetAddress1)).toString()
 
     assert.equal(totalStakesSnaphot_before, '0')
     assert.equal(totalCollateralSnapshot_before, '0')
 
     // Check Bob's ICR is between 110 and TCR
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
-    assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(await th.getTCR(contracts)))
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(await th.getTCR(contracts, assetAddress1)))
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
-    const totalStakesSnaphot_After = (await troveManager.totalStakesSnapshot())
-    const totalCollateralSnapshot_After = (await troveManager.totalCollateralSnapshot())
+    const totalStakesSnaphot_After = (await troveManager.totalStakesSnapshot(assetAddress1))
+    const totalCollateralSnapshot_After = (await troveManager.totalCollateralSnapshot(assetAddress1))
 
     // totalStakesSnapshot should have reduced to 22 ether - the sum of Alice's coll( 20 ether) and Dennis' coll (2 ether )
     assert.equal(totalStakesSnaphot_After.toString(), A_coll.add(D_coll))
@@ -771,9 +793,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits KUSD in the Stability Pool
     await stabilityPool.provideToSP(B_totalDebt.add(toBN(1)), ZERO_ADDRESS, { from: alice })
@@ -783,69 +805,68 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('100000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check Bob's Trove is active
-    const bob_TroveStatus_Before = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(bob)
+    const bob_TroveStatus_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(assetAddress1, bob)
 
     assert.equal(bob_TroveStatus_Before, 1) // status enum element 1 corresponds to "Active"
     assert.isTrue(bob_Trove_isInSortedList_Before)
 
     // Check Bob's ICR is between 110 and TCR
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
-    assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(await th.getTCR(contracts)))
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(await th.getTCR(contracts, assetAddress1)))
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     // Check Bob's Trove is closed after liquidation
-    const bob_TroveStatus_After = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_After = await sortedTroves.contains(bob)
+    const bob_TroveStatus_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_After = await sortedTroves.contains(assetAddress1, bob)
 
     assert.equal(bob_TroveStatus_After, 3) // status enum element 3 corresponds to "Closed by liquidation"
     assert.isFalse(bob_Trove_isInSortedList_After)
 
     // check Bob’s collateral surplus
     const bob_remainingCollateral = B_coll.sub(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_remainingCollateral)
     // can claim collateral
-    const bob_balanceBefore = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_expectedBalance = bob_balanceBefore.sub(th.toBN(BOB_GAS * GAS_PRICE))
-    const bob_balanceAfter = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_expectedBalance.add(th.toBN(bob_remainingCollateral)))
+    const bob_balanceBefore = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral)))
   })
 
   it("liquidate(), with 110% < ICR < TCR, and StabilityPool KUSD > debt to liquidate: can liquidate troves out of order", async () => {
     // taking out 1000 KUSD, CR of 200%
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(202, 16)), extraParams: { from: bob } })
-    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(204, 16)), extraParams: { from: carol } })
-    const { collateral: D_coll, totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    const { collateral: E_coll } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
-    const { collateral: F_coll } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(202, 16)), extraParams: { from: bob } })
+    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(204, 16)), extraParams: { from: carol } })
+    const { collateral: D_coll, totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    const { collateral: E_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
+    const { collateral: F_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
 
     const totalLiquidatedDebt = A_totalDebt.add(B_totalDebt).add(C_totalDebt).add(D_totalDebt)
 
-    await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: totalLiquidatedDebt, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: totalLiquidatedDebt, extraParams: { from: whale } })
     await stabilityPool.provideToSP(totalLiquidatedDebt, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
-  
+    const TCR = await th.getTCR(contracts, assetAddress1)
+
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check troves A-D are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
-    const ICR_D = await troveManager.getCurrentICR(dennis, price)
-    
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    const ICR_D = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))
@@ -854,55 +875,52 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // Troves are ordered by ICR, low to high: A, B, C, D.
 
     // Liquidate out of ICR order: D, B, C.  Confirm Recovery Mode is active prior to each.
-    const liquidationTx_D = await troveManager.liquidate(dennis)
-  
-    assert.isTrue(await th.checkRecoveryMode(contracts))
-    const liquidationTx_B = await troveManager.liquidate(bob)
+    const liquidationTx_D = await troveManager.liquidate(assetAddress1, dennis)
 
-    assert.isTrue(await th.checkRecoveryMode(contracts))
-    const liquidationTx_C = await troveManager.liquidate(carol)
-    
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
+    const liquidationTx_B = await troveManager.liquidate(assetAddress1, bob)
+
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
+    const liquidationTx_C = await troveManager.liquidate(assetAddress1, carol)
+
     // Check transactions all succeeded
     assert.isTrue(liquidationTx_D.receipt.status)
     assert.isTrue(liquidationTx_B.receipt.status)
     assert.isTrue(liquidationTx_C.receipt.status)
 
     // Confirm troves D, B, C removed
-    assert.isFalse(await sortedTroves.contains(dennis))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
 
     // Confirm troves have status 'closed by liquidation' (Status enum element idx 3)
-    assert.equal((await troveManager.Troves(dennis))[3], '3')
-    assert.equal((await troveManager.Troves(bob))[3], '3')
-    assert.equal((await troveManager.Troves(carol))[3], '3')
+    assert.equal((await troveManager.Troves(dennis, assetAddress1))[TroveData.status], '3')
+    assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status], '3')
+    assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status], '3')
 
     // check collateral surplus
     const dennis_remainingCollateral = D_coll.sub(D_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
     const bob_remainingCollateral = B_coll.sub(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
     const carol_remainingCollateral = C_coll.sub(C_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(dennis), dennis_remainingCollateral)
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_remainingCollateral)
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(carol), carol_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, dennis), dennis_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, carol), carol_remainingCollateral)
 
     // can claim collateral
-    const dennis_balanceBefore = th.toBN(await web3.eth.getBalance(dennis))
-    const DENNIS_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: dennis, gasPrice: GAS_PRICE  }))
-    const dennis_expectedBalance = dennis_balanceBefore.sub(th.toBN(DENNIS_GAS * GAS_PRICE))
-    const dennis_balanceAfter = th.toBN(await web3.eth.getBalance(dennis))
-    assert.isTrue(dennis_balanceAfter.eq(dennis_expectedBalance.add(th.toBN(dennis_remainingCollateral))))
+    const dennis_balanceBefore = th.toBN(await erc20Asset1.balanceOf(dennis))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: dennis, gasPrice: GAS_PRICE })
+    const dennis_balanceAfter = th.toBN(await erc20Asset1.balanceOf(dennis))
+    assert.isTrue(dennis_balanceAfter.eq(dennis_balanceBefore.add(th.toBN(dennis_remainingCollateral))))
 
-    const bob_balanceBefore = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_expectedBalance = bob_balanceBefore.sub(th.toBN(BOB_GAS * GAS_PRICE))
-    const bob_balanceAfter = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_expectedBalance.add(th.toBN(bob_remainingCollateral)))
+    const bob_balanceBefore = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral)))
 
-    const carol_balanceBefore = th.toBN(await web3.eth.getBalance(carol))
-    const CAROL_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: carol, gasPrice: GAS_PRICE  }))
-    const carol_expectedBalance = carol_balanceBefore.sub(th.toBN(CAROL_GAS * GAS_PRICE))
-    const carol_balanceAfter = th.toBN(await web3.eth.getBalance(carol))
-    th.assertIsApproximatelyEqual(carol_balanceAfter, carol_expectedBalance.add(th.toBN(carol_remainingCollateral)))
+    const carol_balanceBefore = th.toBN(await erc20Asset1.balanceOf(carol))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: carol, gasPrice: GAS_PRICE })
+    const carol_balanceAfter = th.toBN(await erc20Asset1.balanceOf(carol))
+    th.assertIsApproximatelyEqual(carol_balanceAfter, carol_balanceBefore.add(th.toBN(carol_remainingCollateral)))
   })
 
 
@@ -913,9 +931,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits 1490 KUSD in the Stability Pool
     await stabilityPool.provideToSP('1490000000000000000000', ZERO_ADDRESS, { from: alice })
@@ -924,24 +942,24 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check Bob's Trove is active
-    const bob_TroveStatus_Before = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(bob)
+    const bob_TroveStatus_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(assetAddress1, bob)
 
     assert.equal(bob_TroveStatus_Before, 1) // status enum element 1 corresponds to "Active"
     assert.isTrue(bob_Trove_isInSortedList_Before)
 
     // Try to liquidate Bob
-    await assertRevert(troveManager.liquidate(bob, { from: owner }), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, bob, { from: owner }), "TroveManager: nothing to liquidate")
 
     /* Since the pool only contains 100 KUSD, and Bob's pre-liquidation debt was 250 KUSD,
     expect Bob's trove to remain untouched, and remain active after liquidation */
 
-    const bob_TroveStatus_After = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_After = await sortedTroves.contains(bob)
+    const bob_TroveStatus_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_After = await sortedTroves.contains(assetAddress1, bob)
 
     assert.equal(bob_TroveStatus_After, 1) // status enum element 1 corresponds to "Active"
     assert.isTrue(bob_Trove_isInSortedList_After)
@@ -951,9 +969,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits 100 KUSD in the Stability Pool
     await stabilityPool.provideToSP(dec(100, 18), ZERO_ADDRESS, { from: alice })
@@ -962,29 +980,29 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check Bob's Trove is active
-    const bob_TroveStatus_Before = (await troveManager.Troves(bob))[3]
-    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(bob)
+    const bob_TroveStatus_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.status]
+    const bob_Trove_isInSortedList_Before = await sortedTroves.contains(assetAddress1, bob)
 
     assert.equal(bob_TroveStatus_Before, 1) // status enum element 1 corresponds to "Active"
     assert.isTrue(bob_Trove_isInSortedList_Before)
 
     // Try to liquidate Bob
-    await assertRevert(troveManager.liquidate(bob, { from: owner }), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, bob, { from: owner }), "TroveManager: nothing to liquidate")
 
     /* Since the pool only contains 100 KUSD, and Bob's pre-liquidation debt was 250 KUSD, 
     expect Bob's trove to only be partially offset, and remain active after liquidation */
 
     // Check Bob is in Trove owners array
-    const arrayLength = (await troveManager.getTroveOwnersCount()).toNumber()
+    const arrayLength = (await troveManager.getTroveOwnersCount(assetAddress1)).toNumber()
     let addressFound = false;
     let addressIdx = 0;
 
     for (let i = 0; i < arrayLength; i++) {
-      const address = (await troveManager.TroveOwners(i)).toString()
+      const address = (await troveManager.TroveOwners(assetAddress1, i)).toString()
       if (address == bob) {
         addressFound = true
         addressIdx = i
@@ -994,7 +1012,7 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.isTrue(addressFound);
 
     // Check TroveOwners idx on trove struct == idx of address found in TroveOwners array
-    const idxOnStruct = (await troveManager.Troves(bob))[4].toString()
+    const idxOnStruct = (await troveManager.Troves(bob, assetAddress1))[TroveData.arrayIndex].toString()
     assert.equal(addressIdx.toString(), idxOnStruct)
   })
 
@@ -1002,9 +1020,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits 100 KUSD in the Stability Pool
     await stabilityPool.provideToSP(dec(100, 18), ZERO_ADDRESS, { from: alice })
@@ -1013,11 +1031,11 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Try to liquidate Bob
-    await assertRevert(troveManager.liquidate(bob, { from: owner }), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, bob, { from: owner }), "TroveManager: nothing to liquidate")
 
     /*  Since Bob's debt (250 KUSD) is larger than all KUSD in the Stability Pool, Liquidation won’t happen
 
@@ -1027,16 +1045,16 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     Bob's new coll and stake should remain the same, and the updated totalStakes should still equal 25 ether.
     */
-    const bob_Trove = await troveManager.Troves(bob)
-    const bob_DebtAfter = bob_Trove[0].toString()
-    const bob_CollAfter = bob_Trove[1].toString()
-    const bob_StakeAfter = bob_Trove[2].toString()
+    const bob_Trove = await troveManager.Troves(bob, assetAddress1)
+    const bob_DebtAfter = bob_Trove[TroveData.debt].toString()
+    const bob_CollAfter = bob_Trove[TroveData.coll].toString()
+    const bob_StakeAfter = bob_Trove[TroveData.stake].toString()
 
     th.assertIsApproximatelyEqual(bob_DebtAfter, B_totalDebt)
     assert.equal(bob_CollAfter.toString(), B_coll)
     assert.equal(bob_StakeAfter.toString(), B_coll)
 
-    const totalStakes_After = (await troveManager.totalStakes()).toString()
+    const totalStakes_After = (await troveManager.totalStakes(assetAddress1)).toString()
     assert.equal(totalStakes_After.toString(), A_coll.add(B_coll).add(D_coll))
   })
 
@@ -1044,9 +1062,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits 100 KUSD in the Stability Pool
     await stabilityPool.provideToSP(dec(100, 18), ZERO_ADDRESS, { from: alice })
@@ -1055,25 +1073,25 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check snapshots before
-    const totalStakesSnaphot_Before = (await troveManager.totalStakesSnapshot()).toString()
-    const totalCollateralSnapshot_Before = (await troveManager.totalCollateralSnapshot()).toString()
+    const totalStakesSnaphot_Before = (await troveManager.totalStakesSnapshot(assetAddress1)).toString()
+    const totalCollateralSnapshot_Before = (await troveManager.totalCollateralSnapshot(assetAddress1)).toString()
 
     assert.equal(totalStakesSnaphot_Before, 0)
     assert.equal(totalCollateralSnapshot_Before, 0)
 
     // Liquidate Bob, it won’t happen as there are no funds in the SP
-    await assertRevert(troveManager.liquidate(bob, { from: owner }), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, bob, { from: owner }), "TroveManager: nothing to liquidate")
 
     /* After liquidation, totalStakes snapshot should still equal the total stake: 25 ether
 
     Since there has been no redistribution, the totalCollateral snapshot should equal the totalStakes snapshot: 25 ether.*/
 
-    const totalStakesSnaphot_After = (await troveManager.totalStakesSnapshot()).toString()
-    const totalCollateralSnapshot_After = (await troveManager.totalCollateralSnapshot()).toString()
+    const totalStakesSnaphot_After = (await troveManager.totalStakesSnapshot(assetAddress1)).toString()
+    const totalCollateralSnapshot_After = (await troveManager.totalCollateralSnapshot(assetAddress1)).toString()
 
     assert.equal(totalStakesSnaphot_After, totalStakesSnaphot_Before)
     assert.equal(totalCollateralSnapshot_After, totalCollateralSnapshot_Before)
@@ -1083,9 +1101,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
 
     // Alice deposits 100 KUSD in the Stability Pool
     await stabilityPool.provideToSP(dec(100, 18), ZERO_ADDRESS, { from: alice })
@@ -1094,16 +1112,16 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Try to liquidate Bob. Shouldn’t happen
-    await assertRevert(troveManager.liquidate(bob, { from: owner }), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, bob, { from: owner }), "TroveManager: nothing to liquidate")
 
     // check Stability Pool rewards. Nothing happened, so everything should remain the same
 
     const aliceExpectedDeposit = await stabilityPool.getCompoundedKUSDDeposit(alice)
-    const aliceExpectedETHGain = await stabilityPool.getDepositorETHGain(alice)
+    const aliceExpectedETHGain = await stabilityPool.getDepositorAssetGain(alice)
 
     assert.equal(aliceExpectedDeposit.toString(), dec(100, 18))
     assert.equal(aliceExpectedETHGain.toString(), '0')
@@ -1111,8 +1129,8 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     /* For this Recovery Mode test case with ICR > 110%, there should be no redistribution of remainder to active Troves. 
     Redistribution rewards-per-unit-staked should be zero. */
 
-    const L_KUSDDebt_After = (await troveManager.L_KUSDDebt()).toString()
-    const L_ETH_After = (await troveManager.L_ETH()).toString()
+    const L_KUSDDebt_After = (await troveManager.L_KUSDDebts(assetAddress1)).toString()
+    const L_ETH_After = (await troveManager.L_ASSETS(assetAddress1)).toString()
 
     assert.equal(L_KUSDDebt_After, '0')
     assert.equal(L_ETH_After, '0')
@@ -1123,10 +1141,10 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // Alice withdraws up to 1500 KUSD of debt, and Dennis up to 150, resulting in ICRs of 266%.
     // Bob withdraws up to 250 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
     // Carol withdraws up to debt of 240 KUSD, -> ICR of 250%.
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
-    const { collateral: C_coll } = await openTrove({ ICR: toBN(dec(250, 16)), extraKUSDAmount: dec(240, 18), extraParams: { from: carol } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(1500, 18), extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(250, 18), extraParams: { from: bob } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: dec(2000, 18), extraParams: { from: dennis } })
+    const { collateral: C_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraKUSDAmount: dec(240, 18), extraParams: { from: carol } })
 
     // Alice deposits 100 KUSD in the Stability Pool
     await stabilityPool.provideToSP(dec(100, 18), ZERO_ADDRESS, { from: alice })
@@ -1136,34 +1154,34 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice(dec(100, 18))
     const price = await priceFeed.getPrice()
 
-    const bob_ICR_Before = (await troveManager.getCurrentICR(bob, price)).toString()
-    const carol_ICR_Before = (await troveManager.getCurrentICR(carol, price)).toString()
+    const bob_ICR_Before = (await troveManager.getCurrentICR(assetAddress1, bob, price)).toString()
+    const carol_ICR_Before = (await troveManager.getCurrentICR(assetAddress1, carol, price)).toString()
 
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const bob_Coll_Before = (await troveManager.Troves(bob))[1]
-    const bob_Debt_Before = (await troveManager.Troves(bob))[0]
+    const bob_Coll_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const bob_Debt_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.debt]
 
     // confirm Bob is last trove in list, and has >110% ICR
-    assert.equal((await sortedTroves.getLast()).toString(), bob)
-    assert.isTrue((await troveManager.getCurrentICR(bob, price)).gt(mv._MCR))
+    assert.equal((await sortedTroves.getLast(assetAddress1)).toString(), bob)
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, bob, price)).gt(mv._MCR))
 
     // L1: Try to liquidate Bob. Nothing happens
-    await assertRevert(troveManager.liquidate(bob, { from: owner }), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, bob, { from: owner }), "TroveManager: nothing to liquidate")
 
     //Check SP KUSD has been completely emptied
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), dec(100, 18))
 
     // Check Bob remains active
-    assert.isTrue(await sortedTroves.contains(bob))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, bob))
 
     // Check Bob's collateral and debt remains the same
-    const bob_Coll_After = (await troveManager.Troves(bob))[1]
-    const bob_Debt_After = (await troveManager.Troves(bob))[0]
+    const bob_Coll_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const bob_Debt_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.debt]
     assert.isTrue(bob_Coll_After.eq(bob_Coll_Before))
     assert.isTrue(bob_Debt_After.eq(bob_Debt_Before))
 
-    const bob_ICR_After = (await troveManager.getCurrentICR(bob, price)).toString()
+    const bob_ICR_After = (await troveManager.getCurrentICR(assetAddress1, bob, price)).toString()
 
     // check Bob's ICR has not changed
     assert.equal(bob_ICR_After, bob_ICR_Before)
@@ -1174,42 +1192,42 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     // Remove Bob from system to test Carol's trove: price rises, Bob closes trove, price drops to 100 again
     await priceFeed.setPrice(dec(200, 18))
-    await borrowerOperations.closeTrove({ from: bob })
+    await borrowerOperations.closeTrove(assetAddress1, { from: bob })
     await priceFeed.setPrice(dec(100, 18))
-    assert.isFalse(await sortedTroves.contains(bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
 
     // Alice provides another 50 KUSD to pool
     await stabilityPool.provideToSP(dec(50, 18), ZERO_ADDRESS, { from: alice })
 
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const carol_Coll_Before = (await troveManager.Troves(carol))[1]
-    const carol_Debt_Before = (await troveManager.Troves(carol))[0]
+    const carol_Coll_Before = (await troveManager.Troves(carol, assetAddress1))[TroveData.coll]
+    const carol_Debt_Before = (await troveManager.Troves(carol, assetAddress1))[TroveData.debt]
 
     // Confirm Carol is last trove in list, and has >110% ICR
-    assert.equal((await sortedTroves.getLast()), carol)
-    assert.isTrue((await troveManager.getCurrentICR(carol, price)).gt(mv._MCR))
+    assert.equal((await sortedTroves.getLast(assetAddress1)), carol)
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, carol, price)).gt(mv._MCR))
 
     // L2: Try to liquidate Carol. Nothing happens
-    await assertRevert(troveManager.liquidate(carol), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, carol), "TroveManager: nothing to liquidate")
 
     //Check SP KUSD has been completely emptied
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), dec(150, 18))
 
     // Check Carol's collateral and debt remains the same
-    const carol_Coll_After = (await troveManager.Troves(carol))[1]
-    const carol_Debt_After = (await troveManager.Troves(carol))[0]
+    const carol_Coll_After = (await troveManager.Troves(carol, assetAddress1))[TroveData.coll]
+    const carol_Debt_After = (await troveManager.Troves(carol, assetAddress1))[TroveData.debt]
     assert.isTrue(carol_Coll_After.eq(carol_Coll_Before))
     assert.isTrue(carol_Debt_After.eq(carol_Debt_Before))
 
-    const carol_ICR_After = (await troveManager.getCurrentICR(carol, price)).toString()
+    const carol_ICR_After = (await troveManager.getCurrentICR(assetAddress1, carol, price)).toString()
 
     // check Carol's ICR has not changed
     assert.equal(carol_ICR_After, carol_ICR_Before)
 
     //Confirm liquidations have not led to any redistributions to troves
-    const L_KUSDDebt_After = (await troveManager.L_KUSDDebt()).toString()
-    const L_ETH_After = (await troveManager.L_ETH()).toString()
+    const L_KUSDDebt_After = (await troveManager.L_KUSDDebts(assetAddress1)).toString()
+    const L_ETH_After = (await troveManager.L_ASSETS(assetAddress1)).toString()
 
     assert.equal(L_KUSDDebt_After, '0')
     assert.equal(L_ETH_After, '0')
@@ -1217,35 +1235,35 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
   it("liquidate() with ICR > 110%, and StabilityPool KUSD < liquidated debt: total liquidated coll and debt is correct", async () => {
     // Whale provides 50 KUSD to the SP
-    await openTrove({ ICR: toBN(dec(300, 16)), extraKUSDAmount: dec(50, 18), extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraKUSDAmount: dec(50, 18), extraParams: { from: whale } })
     await stabilityPool.provideToSP(dec(50, 18), ZERO_ADDRESS, { from: whale })
 
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll } = await openTrove({ ICR: toBN(dec(202, 16)), extraParams: { from: bob } })
-    const { collateral: C_coll } = await openTrove({ ICR: toBN(dec(204, 16)), extraParams: { from: carol } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    const { collateral: E_coll } = await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(202, 16)), extraParams: { from: bob } })
+    const { collateral: C_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(204, 16)), extraParams: { from: carol } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    const { collateral: E_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check C is in range 110% < ICR < 150%
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(await th.getTCR(contracts)))
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(await th.getTCR(contracts, assetAddress1)))
 
-    const entireSystemCollBefore = await troveManager.getEntireSystemColl()
-    const entireSystemDebtBefore = await troveManager.getEntireSystemDebt()
+    const entireSystemCollBefore = await troveManager.getEntireSystemColl(assetAddress1)
+    const entireSystemDebtBefore = await troveManager.getEntireSystemDebt(assetAddress1)
 
     // Try to liquidate Alice
-    await assertRevert(troveManager.liquidate(alice), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, alice), "TroveManager: nothing to liquidate")
 
     // Expect system debt and system coll not reduced
-    const entireSystemCollAfter = await troveManager.getEntireSystemColl()
-    const entireSystemDebtAfter = await troveManager.getEntireSystemDebt()
+    const entireSystemCollAfter = await troveManager.getEntireSystemColl(assetAddress1)
+    const entireSystemDebtAfter = await troveManager.getEntireSystemDebt(assetAddress1)
 
     const changeInEntireSystemColl = entireSystemCollBefore.sub(entireSystemCollAfter)
     const changeInEntireSystemDebt = entireSystemDebtBefore.sub(entireSystemDebtAfter)
@@ -1258,89 +1276,89 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
   it("liquidate(): Doesn't liquidate undercollateralized trove if it is the only trove in the system", async () => {
     // Alice creates a single trove with 0.62 ETH and a debt of 62 KUSD, and provides 10 KUSD to SP
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
     await stabilityPool.provideToSP(dec(10, 18), ZERO_ADDRESS, { from: alice })
 
-    assert.isFalse(await th.checkRecoveryMode(contracts))
+    assert.isFalse(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Set ETH:USD price to 105
     await priceFeed.setPrice('105000000000000000000')
     const price = await priceFeed.getPrice()
 
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const alice_ICR = (await troveManager.getCurrentICR(alice, price)).toString()
+    const alice_ICR = (await troveManager.getCurrentICR(assetAddress1, alice, price)).toString()
     assert.equal(alice_ICR, '1050000000000000000')
 
-    const activeTrovesCount_Before = await troveManager.getTroveOwnersCount()
+    const activeTrovesCount_Before = await troveManager.getTroveOwnersCount(assetAddress1)
 
     assert.equal(activeTrovesCount_Before, 1)
 
     // Try to liquidate the trove
-    await assertRevert(troveManager.liquidate(alice, { from: owner }), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, alice, { from: owner }), "TroveManager: nothing to liquidate")
 
     // Check Alice's trove has not been removed
-    const activeTrovesCount_After = await troveManager.getTroveOwnersCount()
+    const activeTrovesCount_After = await troveManager.getTroveOwnersCount(assetAddress1)
     assert.equal(activeTrovesCount_After, 1)
 
-    const alice_isInSortedList = await sortedTroves.contains(alice)
+    const alice_isInSortedList = await sortedTroves.contains(assetAddress1, alice)
     assert.isTrue(alice_isInSortedList)
   })
 
   it("liquidate(): Liquidates undercollateralized trove if there are two troves in the system", async () => {
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: bob } })
 
     // Alice creates a single trove with 0.62 ETH and a debt of 62 KUSD, and provides 10 KUSD to SP
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
 
     // Alice proves 10 KUSD to SP
     await stabilityPool.provideToSP(dec(10, 18), ZERO_ADDRESS, { from: alice })
 
-    assert.isFalse(await th.checkRecoveryMode(contracts))
+    assert.isFalse(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Set ETH:USD price to 105
     await priceFeed.setPrice('105000000000000000000')
     const price = await priceFeed.getPrice()
 
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const alice_ICR = (await troveManager.getCurrentICR(alice, price)).toString()
+    const alice_ICR = (await troveManager.getCurrentICR(assetAddress1, alice, price)).toString()
     assert.equal(alice_ICR, '1050000000000000000')
 
-    const activeTrovesCount_Before = await troveManager.getTroveOwnersCount()
+    const activeTrovesCount_Before = await troveManager.getTroveOwnersCount(assetAddress1)
 
     assert.equal(activeTrovesCount_Before, 2)
 
     // Liquidate the trove
-    await troveManager.liquidate(alice, { from: owner })
+    await troveManager.liquidate(assetAddress1, alice, { from: owner })
 
     // Check Alice's trove is removed, and bob remains
-    const activeTrovesCount_After = await troveManager.getTroveOwnersCount()
+    const activeTrovesCount_After = await troveManager.getTroveOwnersCount(assetAddress1)
     assert.equal(activeTrovesCount_After, 1)
 
-    const alice_isInSortedList = await sortedTroves.contains(alice)
+    const alice_isInSortedList = await sortedTroves.contains(assetAddress1, alice)
     assert.isFalse(alice_isInSortedList)
 
-    const bob_isInSortedList = await sortedTroves.contains(bob)
+    const bob_isInSortedList = await sortedTroves.contains(assetAddress1, bob)
     assert.isTrue(bob_isInSortedList)
   })
 
   it("liquidate(): does nothing if trove has >= 110% ICR and the Stability Pool is empty", async () => {
-    await openTrove({ ICR: toBN(dec(400, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(220, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(266, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(400, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraParams: { from: carol } })
 
     await priceFeed.setPrice(dec(100, 18))
     const price = await priceFeed.getPrice()
 
-    const TCR_Before = (await th.getTCR(contracts)).toString()
-    const listSize_Before = (await sortedTroves.getSize()).toString()
+    const TCR_Before = (await th.getTCR(contracts, assetAddress1)).toString()
+    const listSize_Before = (await sortedTroves.getSize(assetAddress1)).toString()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check Bob's ICR > 110%
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
     assert.isTrue(bob_ICR.gte(mv._MCR))
 
     // Confirm SP is empty
@@ -1348,71 +1366,71 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.equal(KUSDinSP, '0')
 
     // Attempt to liquidate bob
-    await assertRevert(troveManager.liquidate(bob), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, bob), "TroveManager: nothing to liquidate")
 
     // check A, B, C remain active
-    assert.isTrue((await sortedTroves.contains(bob)))
-    assert.isTrue((await sortedTroves.contains(alice)))
-    assert.isTrue((await sortedTroves.contains(carol)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, bob)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, alice)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, carol)))
 
-    const TCR_After = (await th.getTCR(contracts)).toString()
-    const listSize_After = (await sortedTroves.getSize()).toString()
+    const TCR_After = (await th.getTCR(contracts, assetAddress1)).toString()
+    const listSize_After = (await sortedTroves.getSize(assetAddress1)).toString()
 
     // Check TCR and list size have not changed
     assert.equal(TCR_Before, TCR_After)
     assert.equal(listSize_Before, listSize_After)
   })
 
-  it("liquidate(): does nothing if trove ICR >= TCR, and SP covers trove's debt", async () => { 
-    await openTrove({ ICR: toBN(dec(166, 16)), extraParams: { from: A } })
-    await openTrove({ ICR: toBN(dec(154, 16)), extraParams: { from: B } })
-    await openTrove({ ICR: toBN(dec(142, 16)), extraParams: { from: C } })
+  it("liquidate(): does nothing if trove ICR >= TCR, and SP covers trove's debt", async () => {
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(166, 16)), extraParams: { from: A } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(154, 16)), extraParams: { from: B } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(142, 16)), extraParams: { from: C } })
 
     // C fills SP with 130 KUSD
-    await stabilityPool.provideToSP(dec(130, 18), ZERO_ADDRESS, {from: C})
+    await stabilityPool.provideToSP(dec(130, 18), ZERO_ADDRESS, { from: C })
 
     await priceFeed.setPrice(dec(150, 18))
     const price = await priceFeed.getPrice()
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
-    const ICR_A = await troveManager.getCurrentICR(A, price)
-    const ICR_B = await troveManager.getCurrentICR(B, price)
-    const ICR_C = await troveManager.getCurrentICR(C, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, A, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, B, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, C, price)
 
     assert.isTrue(ICR_A.gt(TCR))
     // Try to liquidate A
-    await assertRevert(troveManager.liquidate(A), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidate(assetAddress1, A), "TroveManager: nothing to liquidate")
 
     // Check liquidation of A does nothing - trove remains in system
-    assert.isTrue(await sortedTroves.contains(A))
-    assert.equal(await troveManager.getTroveStatus(A), 1) // Status 1 -> active
+    assert.isTrue(await sortedTroves.contains(assetAddress1, A))
+    assert.equal(await troveManager.getTroveStatus(assetAddress1, A), 1) // Status 1 -> active
 
     // Check C, with ICR < TCR, can be liquidated
     assert.isTrue(ICR_C.lt(TCR))
-    const liqTxC = await troveManager.liquidate(C)
+    const liqTxC = await troveManager.liquidate(assetAddress1, C)
     assert.isTrue(liqTxC.receipt.status)
 
-    assert.isFalse(await sortedTroves.contains(C))
-    assert.equal(await troveManager.getTroveStatus(C), 3) // Status liquidated
+    assert.isFalse(await sortedTroves.contains(assetAddress1, C))
+    assert.equal(await troveManager.getTroveStatus(assetAddress1, C), 3) // Status liquidated
   })
 
   it("liquidate(): reverts if trove is non-existent", async () => {
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(133, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(133, 16)), extraParams: { from: bob } })
 
     await priceFeed.setPrice(dec(100, 18))
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check Carol does not have an existing trove
-    assert.equal(await troveManager.getTroveStatus(carol), 0)
-    assert.isFalse(await sortedTroves.contains(carol))
+    assert.equal(await troveManager.getTroveStatus(assetAddress1, carol), 0)
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
 
     try {
-      await troveManager.liquidate(carol)
+      await troveManager.liquidate(assetAddress1, carol)
 
       assert.isFalse(txCarol.receipt.status)
     } catch (err) {
@@ -1421,51 +1439,51 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   })
 
   it("liquidate(): reverts if trove has been closed", async () => {
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(133, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(133, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(133, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(133, 16)), extraParams: { from: carol } })
 
-    assert.isTrue(await sortedTroves.contains(carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
 
     // Price drops, Carol ICR falls below MCR
     await priceFeed.setPrice(dec(100, 18))
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Carol liquidated, and her trove is closed
-    const txCarol_L1 = await troveManager.liquidate(carol)
+    const txCarol_L1 = await troveManager.liquidate(assetAddress1, carol)
     assert.isTrue(txCarol_L1.receipt.status)
 
     // Check Carol's trove is closed by liquidation
-    assert.isFalse(await sortedTroves.contains(carol))
-    assert.equal(await troveManager.getTroveStatus(carol), 3)
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
+    assert.equal(await troveManager.getTroveStatus(assetAddress1, carol), 3)
 
     try {
-      await troveManager.liquidate(carol)
+      await troveManager.liquidate(assetAddress1, carol)
     } catch (err) {
       assert.include(err.message, "revert")
     }
   })
 
   it("liquidate(): liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
-    await openTrove({ ICR: toBN(dec(400, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(220, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(400, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
 
     // Defaulter opens with 60 KUSD, 0.6 ETH
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: defaulter_1 } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: defaulter_1 } })
 
     // Price drops
     await priceFeed.setPrice(dec(100, 18))
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const alice_ICR_Before = await troveManager.getCurrentICR(alice, price)
-    const bob_ICR_Before = await troveManager.getCurrentICR(bob, price)
-    const carol_ICR_Before = await troveManager.getCurrentICR(carol, price)
+    const alice_ICR_Before = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const bob_ICR_Before = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const carol_ICR_Before = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     /* Before liquidation: 
     Alice ICR: = (1 * 100 / 50) = 200%
@@ -1478,11 +1496,11 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.isTrue(carol_ICR_Before.lte(mv._MCR))
 
     // Liquidate defaulter. 30 KUSD and 0.3 ETH is distributed uniformly between A, B and C. Each receive 10 KUSD, 0.1 ETH
-    await troveManager.liquidate(defaulter_1)
+    await troveManager.liquidate(assetAddress1, defaulter_1)
 
-    const alice_ICR_After = await troveManager.getCurrentICR(alice, price)
-    const bob_ICR_After = await troveManager.getCurrentICR(bob, price)
-    const carol_ICR_After = await troveManager.getCurrentICR(carol, price)
+    const alice_ICR_After = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const bob_ICR_After = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const carol_ICR_After = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     /* After liquidation: 
 
@@ -1497,34 +1515,34 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     /* Though Bob's true ICR (including pending rewards) is below the MCR, 
     check that Bob's raw coll and debt has not changed, and that his "raw" ICR is above the MCR */
-    const bob_Coll = (await troveManager.Troves(bob))[1]
-    const bob_Debt = (await troveManager.Troves(bob))[0]
+    const bob_Coll = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const bob_Debt = (await troveManager.Troves(bob, assetAddress1))[TroveData.debt]
 
     const bob_rawICR = bob_Coll.mul(th.toBN(dec(100, 18))).div(bob_Debt)
     assert.isTrue(bob_rawICR.gte(mv._MCR))
 
     //liquidate A, B, C
-    await assertRevert(troveManager.liquidate(alice), "TroveManager: nothing to liquidate")
-    await troveManager.liquidate(bob)
-    await troveManager.liquidate(carol)
+    await assertRevert(troveManager.liquidate(assetAddress1, alice), "TroveManager: nothing to liquidate")
+    await troveManager.liquidate(assetAddress1, bob)
+    await troveManager.liquidate(assetAddress1, carol)
 
     /*  Since there is 0 KUSD in the stability Pool, A, with ICR >110%, should stay active.
     Check Alice stays active, Carol gets liquidated, and Bob gets liquidated 
     (because his pending rewards bring his ICR < MCR) */
-    assert.isTrue(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
 
     // check trove statuses - A active (1), B and C liquidated (3)
-    assert.equal((await troveManager.Troves(alice))[3].toString(), '1')
-    assert.equal((await troveManager.Troves(bob))[3].toString(), '3')
-    assert.equal((await troveManager.Troves(carol))[3].toString(), '3')
+    assert.equal((await troveManager.Troves(alice, assetAddress1))[TroveData.status].toString(), '1')
+    assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status].toString(), '3')
+    assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status].toString(), '3')
   })
 
   it("liquidate(): does not affect the SP deposit or ETH gain when called on an SP depositor's address that has no trove", async () => {
-    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
+    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
     const spDeposit = C_totalDebt.add(toBN(dec(1000, 18)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: bob } })
 
     // Bob sends tokens to Dennis, who has no trove
     await kusdToken.transfer(dennis, spDeposit, { from: bob })
@@ -1536,42 +1554,42 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice(dec(105, 18))
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Carol gets liquidated
-    await troveManager.liquidate(carol)
+    await troveManager.liquidate(assetAddress1, carol)
 
     // Check Dennis' SP deposit has absorbed Carol's debt, and he has received her liquidated ETH
     const dennis_Deposit_Before = (await stabilityPool.getCompoundedKUSDDeposit(dennis)).toString()
-    const dennis_ETHGain_Before = (await stabilityPool.getDepositorETHGain(dennis)).toString()
+    const dennis_ETHGain_Before = (await stabilityPool.getDepositorAssetGain(dennis)).toString()
     assert.isAtMost(th.getDifference(dennis_Deposit_Before, spDeposit.sub(C_totalDebt)), 1000)
     assert.isAtMost(th.getDifference(dennis_ETHGain_Before, th.applyLiquidationFee(C_coll)), 1000)
 
     // Attempt to liquidate Dennis
     try {
-      await troveManager.liquidate(dennis)
+      await troveManager.liquidate(assetAddress1, dennis)
     } catch (err) {
       assert.include(err.message, "revert")
     }
 
     // Check Dennis' SP deposit does not change after liquidation attempt
     const dennis_Deposit_After = (await stabilityPool.getCompoundedKUSDDeposit(dennis)).toString()
-    const dennis_ETHGain_After = (await stabilityPool.getDepositorETHGain(dennis)).toString()
+    const dennis_ETHGain_After = (await stabilityPool.getDepositorAssetGain(dennis)).toString()
     assert.equal(dennis_Deposit_Before, dennis_Deposit_After)
     assert.equal(dennis_ETHGain_Before, dennis_ETHGain_After)
   })
 
   it("liquidate(): does not alter the liquidated user's token balance", async () => {
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: dec(1000, 18), extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: dec(1000, 18), extraParams: { from: whale } })
 
-    const { kusdAmount: A_kusdAmount } = await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(300, 18), extraParams: { from: alice } })
-    const { kusdAmount: B_kusdAmount } = await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(200, 18), extraParams: { from: bob } })
-    const { kusdAmount: C_kusdAmount } = await openTrove({ ICR: toBN(dec(206, 16)), extraKUSDAmount: dec(100, 18), extraParams: { from: carol } })
+    const { kusdAmount: A_kusdAmount } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(300, 18), extraParams: { from: alice } })
+    const { kusdAmount: B_kusdAmount } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(200, 18), extraParams: { from: bob } })
+    const { kusdAmount: C_kusdAmount } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraKUSDAmount: dec(100, 18), extraParams: { from: carol } })
 
     await priceFeed.setPrice(dec(105, 18))
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check token balances 
     assert.equal((await kusdToken.balanceOf(alice)).toString(), A_kusdAmount)
@@ -1579,20 +1597,20 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.equal((await kusdToken.balanceOf(carol)).toString(), C_kusdAmount)
 
     // Check sortedList size is 4
-    assert.equal((await sortedTroves.getSize()).toString(), '4')
+    assert.equal((await sortedTroves.getSize(assetAddress1)).toString(), '4')
 
     // Liquidate A, B and C
-    await troveManager.liquidate(alice)
-    await troveManager.liquidate(bob)
-    await troveManager.liquidate(carol)
+    await troveManager.liquidate(assetAddress1, alice)
+    await troveManager.liquidate(assetAddress1, bob)
+    await troveManager.liquidate(assetAddress1, carol)
 
     // Confirm A, B, C closed
-    assert.isFalse(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
 
     // Check sortedList size reduced to 1
-    assert.equal((await sortedTroves.getSize()).toString(), '1')
+    assert.equal((await sortedTroves.getSize(assetAddress1)).toString(), '1')
 
     // Confirm token balances have not changed
     assert.equal((await kusdToken.balanceOf(alice)).toString(), A_kusdAmount)
@@ -1604,8 +1622,8 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
     // Alice withdraws up to 1500 KUSD of debt, resulting in ICRs of 266%.
     // Bob withdraws up to 480 KUSD of debt, resulting in ICR of 240%. Bob has lowest ICR.
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(480, 18), extraParams: { from: bob } })
-    const { collateral: A_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: dec(480, 18), extraParams: { from: bob } })
+    const { collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt, extraParams: { from: alice } })
 
     // Alice deposits KUSD in the Stability Pool
     await stabilityPool.provideToSP(B_totalDebt, ZERO_ADDRESS, { from: alice })
@@ -1614,27 +1632,26 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
     let price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check Bob's ICR is between 110 and TCR
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
     assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(TCR))
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     // check Bob’s collateral surplus: 5.76 * 100 - 480 * 1.1
     const bob_remainingCollateral = B_coll.sub(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_remainingCollateral)
     // can claim collateral
-    const bob_balanceBefore = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_expectedBalance = bob_balanceBefore.sub(th.toBN(BOB_GAS * GAS_PRICE))
-    const bob_balanceAfter = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_expectedBalance.add(th.toBN(bob_remainingCollateral)))
+    const bob_balanceBefore = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral)))
 
     // skip bootstrapping phase
     await th.fastForwardTime(timeValues.SECONDS_IN_ONE_WEEK * 2, web3.currentProvider)
@@ -1642,77 +1659,74 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // Bob re-opens the trove, price 200, total debt 80 KUSD, ICR = 120% (lowest one)
     // Dennis redeems 30, so Bob has a surplus of (200 * 0.48 - 30) / 200 = 0.33 ETH
     await priceFeed.setPrice('200000000000000000000')
-    const { collateral: B_coll_2, netDebt: B_netDebt_2 } = await openTrove({ ICR: toBN(dec(150, 16)), extraKUSDAmount: dec(480, 18), extraParams: { from: bob, value: bob_remainingCollateral } })
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_netDebt_2, extraParams: { from: dennis } })
-    await th.redeemCollateral(dennis, contracts, B_netDebt_2,GAS_PRICE)
+    const { collateral: B_coll_2, netDebt: B_netDebt_2 } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(150, 16)), extraKUSDAmount: dec(480, 18), extraParams: { from: bob, value: bob_remainingCollateral } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_netDebt_2, extraParams: { from: dennis } })
+    await th.redeemCollateral(assetAddress1, dennis, contracts, B_netDebt_2, GAS_PRICE)
     price = await priceFeed.getPrice()
     const bob_surplus = B_coll_2.sub(B_netDebt_2.mul(mv._1e18BN).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_surplus)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_surplus)
     // can claim collateral
-    const bob_balanceBefore_2 = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS_2 = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_expectedBalance_2 = bob_balanceBefore_2.sub(th.toBN(BOB_GAS_2 * GAS_PRICE))
-    const bob_balanceAfter_2 = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter_2, bob_expectedBalance_2.add(th.toBN(bob_surplus)))
+    const bob_balanceBefore_2 = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter_2 = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter_2, bob_balanceBefore_2.add(th.toBN(bob_surplus)))
   })
 
   it("liquidate(), with 110% < ICR < TCR, can claim collateral, after another claim from a redemption", async () => {
     // --- SETUP ---
     // Bob withdraws up to 90 KUSD of debt, resulting in ICR of 222%
-    const { collateral: B_coll, netDebt: B_netDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraKUSDAmount: dec(90, 18), extraParams: { from: bob } })
+    const { collateral: B_coll, netDebt: B_netDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraKUSDAmount: dec(90, 18), extraParams: { from: bob } })
     // Dennis withdraws to 150 KUSD of debt, resulting in ICRs of 266%.
-    const { collateral: D_coll } = await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_netDebt, extraParams: { from: dennis } })
+    const { collateral: D_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_netDebt, extraParams: { from: dennis } })
 
     // --- TEST ---
     // skip bootstrapping phase
     await th.fastForwardTime(timeValues.SECONDS_IN_ONE_WEEK * 2, web3.currentProvider)
 
     // Dennis redeems 40, so Bob has a surplus of (200 * 1 - 40) / 200 = 0.8 ETH
-    await th.redeemCollateral(dennis, contracts, B_netDebt, GAS_PRICE)
+    await th.redeemCollateral(assetAddress1, dennis, contracts, B_netDebt, GAS_PRICE)
     let price = await priceFeed.getPrice()
     const bob_surplus = B_coll.sub(B_netDebt.mul(mv._1e18BN).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_surplus)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_surplus)
 
     // can claim collateral
-    const bob_balanceBefore = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_expectedBalance = bob_balanceBefore.sub(th.toBN(BOB_GAS * GAS_PRICE))
-    const bob_balanceAfter = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_expectedBalance.add(bob_surplus))
+    const bob_balanceBefore = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(bob_surplus))
 
     // Bob re-opens the trove, price 200, total debt 250 KUSD, ICR = 240% (lowest one)
-    const { collateral: B_coll_2, totalDebt: B_totalDebt_2 } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: bob, value: _3_Ether } })
+    const { collateral: B_coll_2, totalDebt: B_totalDebt_2 } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: bob, value: _3_Ether } })
     // Alice deposits KUSD in the Stability Pool
-    await openTrove({ ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt_2, extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraKUSDAmount: B_totalDebt_2, extraParams: { from: alice } })
     await stabilityPool.provideToSP(B_totalDebt_2, ZERO_ADDRESS, { from: alice })
 
     // price drops to 1ETH:100KUSD, reducing TCR below 150%
     await priceFeed.setPrice('100000000000000000000')
     price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
-    const recoveryMode = await th.checkRecoveryMode(contracts)
+    const recoveryMode = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode)
 
     // Check Bob's ICR is between 110 and TCR
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
     assert.isTrue(bob_ICR.gt(mv._MCR) && bob_ICR.lt(TCR))
     // debt is increased by fee, due to previous redemption
-    const bob_debt = await troveManager.getTroveDebt(bob)
+    const bob_debt = await troveManager.getTroveDebt(assetAddress1, bob)
 
     // Liquidate Bob
-    await troveManager.liquidate(bob, { from: owner })
+    await troveManager.liquidate(assetAddress1, bob, { from: owner })
 
     // check Bob’s collateral surplus
     const bob_remainingCollateral = B_coll_2.sub(B_totalDebt_2.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual((await collSurplusPool.getCollateral(bob)).toString(), bob_remainingCollateral.toString())
+    th.assertIsApproximatelyEqual((await collSurplusPool.getCollateral(assetAddress1, bob)).toString(), bob_remainingCollateral.toString())
 
     // can claim collateral
-    const bob_balanceBefore_2 = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS_2 = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_expectedBalance_2 = bob_balanceBefore_2.sub(th.toBN(BOB_GAS_2 * GAS_PRICE))
-    const bob_balanceAfter_2 = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter_2, bob_expectedBalance_2.add(th.toBN(bob_remainingCollateral)))
+    const bob_balanceBefore_2 = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter_2 = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter_2, bob_balanceBefore_2.add(th.toBN(bob_remainingCollateral)))
   })
 
   // --- liquidateTroves ---
@@ -1722,15 +1736,15 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // --- SETUP ---
 
     // Everyone withdraws some KUSD from their Trove, resulting in different ICRs
-    await openTrove({ ICR: toBN(dec(350, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(286, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(273, 16)), extraParams: { from: dennis } })
-    const { totalDebt: E_totalDebt } = await openTrove({ ICR: toBN(dec(261, 16)), extraParams: { from: erin } })
-    const { totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(250, 16)), extraParams: { from: freddy } })
-    const { totalDebt: G_totalDebt } = await openTrove({ ICR: toBN(dec(235, 16)), extraParams: { from: greta } })
-    const { totalDebt: H_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraKUSDAmount: dec(5000, 18), extraParams: { from: harry } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(350, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(286, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(273, 16)), extraParams: { from: dennis } })
+    const { totalDebt: E_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(261, 16)), extraParams: { from: erin } })
+    const { totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraParams: { from: freddy } })
+    const { totalDebt: G_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(235, 16)), extraParams: { from: greta } })
+    const { totalDebt: H_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraKUSDAmount: dec(5000, 18), extraParams: { from: harry } })
     const liquidationAmount = E_totalDebt.add(F_totalDebt).add(G_totalDebt).add(H_totalDebt)
-    await openTrove({ ICR: toBN(dec(400, 16)), extraKUSDAmount: liquidationAmount, extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(400, 16)), extraKUSDAmount: liquidationAmount, extraParams: { from: alice } })
 
     // Alice deposits KUSD to Stability Pool
     await stabilityPool.provideToSP(liquidationAmount, ZERO_ADDRESS, { from: alice })
@@ -1740,12 +1754,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice('90000000000000000000')
     const price = await priceFeed.getPrice()
 
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts)
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode_Before)
 
     // check TCR < 150%
     const _150percent = web3.utils.toBN('1500000000000000000')
-    const TCR_Before = await th.getTCR(contracts)
+    const TCR_Before = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_Before.lt(_150percent))
 
     /* 
@@ -1762,15 +1776,15 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Harry       100%
 
     */
-    const alice_ICR = await troveManager.getCurrentICR(alice, price)
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
-    const carol_ICR = await troveManager.getCurrentICR(carol, price)
-    const dennis_ICR = await troveManager.getCurrentICR(dennis, price)
-    const erin_ICR = await troveManager.getCurrentICR(erin, price)
-    const freddy_ICR = await troveManager.getCurrentICR(freddy, price)
-    const greta_ICR = await troveManager.getCurrentICR(greta, price)
-    const harry_ICR = await troveManager.getCurrentICR(harry, price)
-    const TCR = await th.getTCR(contracts)
+    const alice_ICR = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const carol_ICR = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    const dennis_ICR = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    const erin_ICR = await troveManager.getCurrentICR(assetAddress1, erin, price)
+    const freddy_ICR = await troveManager.getCurrentICR(assetAddress1, freddy, price)
+    const greta_ICR = await troveManager.getCurrentICR(assetAddress1, greta, price)
+    const harry_ICR = await troveManager.getCurrentICR(assetAddress1, harry, price)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Alice and Bob should have ICR > TCR
     assert.isTrue(alice_ICR.gt(TCR))
@@ -1804,58 +1818,58 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Only Alice, Bob, Carol and Dennis should remain active - all others should be closed. */
 
     // call liquidate Troves
-    await troveManager.liquidateTroves(10);
+    await troveManager.liquidateTroves(assetAddress1, 10);
 
     // check system is no longer in Recovery Mode
-    const recoveryMode_After = await th.checkRecoveryMode(contracts)
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isFalse(recoveryMode_After)
 
     // After liquidation, TCR should rise to above 150%. 
-    const TCR_After = await th.getTCR(contracts)
+    const TCR_After = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_After.gt(_150percent))
 
     // get all Troves
-    const alice_Trove = await troveManager.Troves(alice)
-    const bob_Trove = await troveManager.Troves(bob)
-    const carol_Trove = await troveManager.Troves(carol)
-    const dennis_Trove = await troveManager.Troves(dennis)
-    const erin_Trove = await troveManager.Troves(erin)
-    const freddy_Trove = await troveManager.Troves(freddy)
-    const greta_Trove = await troveManager.Troves(greta)
-    const harry_Trove = await troveManager.Troves(harry)
+    const alice_Trove = await troveManager.Troves(alice, assetAddress1)
+    const bob_Trove = await troveManager.Troves(bob, assetAddress1)
+    const carol_Trove = await troveManager.Troves(carol, assetAddress1)
+    const dennis_Trove = await troveManager.Troves(dennis, assetAddress1)
+    const erin_Trove = await troveManager.Troves(erin, assetAddress1)
+    const freddy_Trove = await troveManager.Troves(freddy, assetAddress1)
+    const greta_Trove = await troveManager.Troves(greta, assetAddress1)
+    const harry_Trove = await troveManager.Troves(harry, assetAddress1)
 
     // check that Alice, Bob, Carol, & Dennis' Troves remain active
-    assert.equal(alice_Trove[3], 1)
-    assert.equal(bob_Trove[3], 1)
-    assert.equal(carol_Trove[3], 1)
-    assert.equal(dennis_Trove[3], 1)
-    assert.isTrue(await sortedTroves.contains(alice))
-    assert.isTrue(await sortedTroves.contains(bob))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(dennis))
+    assert.equal(alice_Trove[TroveData.status], 1)
+    assert.equal(bob_Trove[TroveData.status], 1)
+    assert.equal(carol_Trove[TroveData.status], 1)
+    assert.equal(dennis_Trove[TroveData.status], 1)
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, bob))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, dennis))
 
     // check all other Troves are liquidated
-    assert.equal(erin_Trove[3], 3)
-    assert.equal(freddy_Trove[3], 3)
-    assert.equal(greta_Trove[3], 3)
-    assert.equal(harry_Trove[3], 3)
-    assert.isFalse(await sortedTroves.contains(erin))
-    assert.isFalse(await sortedTroves.contains(freddy))
-    assert.isFalse(await sortedTroves.contains(greta))
-    assert.isFalse(await sortedTroves.contains(harry))
+    assert.equal(erin_Trove[TroveData.status], 3)
+    assert.equal(freddy_Trove[TroveData.status], 3)
+    assert.equal(greta_Trove[TroveData.status], 3)
+    assert.equal(harry_Trove[TroveData.status], 3)
+    assert.isFalse(await sortedTroves.contains(assetAddress1, erin))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, greta))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, harry))
   })
 
   it("liquidateTroves(): Liquidates Troves until 1) system has left recovery mode AND 2) it reaches a Trove with ICR >= 110%", async () => {
     // make 6 Troves accordingly
     // --- SETUP ---
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: carol } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(230, 16)), extraParams: { from: dennis } })
-    const { totalDebt: E_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
-    const { totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: carol } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(230, 16)), extraParams: { from: dennis } })
+    const { totalDebt: E_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
+    const { totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
 
     const liquidationAmount = B_totalDebt.add(C_totalDebt).add(D_totalDebt).add(E_totalDebt).add(F_totalDebt)
-    await openTrove({ ICR: toBN(dec(400, 16)), extraKUSDAmount: liquidationAmount, extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(400, 16)), extraKUSDAmount: liquidationAmount, extraParams: { from: alice } })
 
     // Alice deposits KUSD to Stability Pool
     await stabilityPool.provideToSP(liquidationAmount, ZERO_ADDRESS, { from: alice })
@@ -1866,12 +1880,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     // check Recovery Mode kicks in
 
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts)
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode_Before)
 
     // check TCR < 150%
     const _150percent = web3.utils.toBN('1500000000000000000')
-    const TCR_Before = await th.getTCR(contracts)
+    const TCR_Before = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_Before.lt(_150percent))
 
     /* 
@@ -1885,12 +1899,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Elisa       102%
     Freddy      102%
     */
-    alice_ICR = await troveManager.getCurrentICR(alice, price)
-    bob_ICR = await troveManager.getCurrentICR(bob, price)
-    carol_ICR = await troveManager.getCurrentICR(carol, price)
-    dennis_ICR = await troveManager.getCurrentICR(dennis, price)
-    erin_ICR = await troveManager.getCurrentICR(erin, price)
-    freddy_ICR = await troveManager.getCurrentICR(freddy, price)
+    alice_ICR = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    carol_ICR = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    dennis_ICR = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    erin_ICR = await troveManager.getCurrentICR(assetAddress1, erin, price)
+    freddy_ICR = await troveManager.getCurrentICR(assetAddress1, freddy, price)
 
     // Alice should have ICR > 150%
     assert.isTrue(alice_ICR.gt(_150percent))
@@ -1910,136 +1924,136 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Only Alice should remain active - all others should be closed. */
 
     // call liquidate Troves
-    await troveManager.liquidateTroves(6);
+    await troveManager.liquidateTroves(assetAddress1, 6);
 
     // check system is no longer in Recovery Mode
-    const recoveryMode_After = await th.checkRecoveryMode(contracts)
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isFalse(recoveryMode_After)
 
     // After liquidation, TCR should rise to above 150%. 
-    const TCR_After = await th.getTCR(contracts)
+    const TCR_After = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_After.gt(_150percent))
 
     // get all Troves
-    const alice_Trove = await troveManager.Troves(alice)
-    const bob_Trove = await troveManager.Troves(bob)
-    const carol_Trove = await troveManager.Troves(carol)
-    const dennis_Trove = await troveManager.Troves(dennis)
-    const erin_Trove = await troveManager.Troves(erin)
-    const freddy_Trove = await troveManager.Troves(freddy)
+    const alice_Trove = await troveManager.Troves(alice, assetAddress1)
+    const bob_Trove = await troveManager.Troves(bob, assetAddress1)
+    const carol_Trove = await troveManager.Troves(carol, assetAddress1)
+    const dennis_Trove = await troveManager.Troves(dennis, assetAddress1)
+    const erin_Trove = await troveManager.Troves(erin, assetAddress1)
+    const freddy_Trove = await troveManager.Troves(freddy, assetAddress1)
 
     // check that Alice's Trove remains active
-    assert.equal(alice_Trove[3], 1)
-    assert.isTrue(await sortedTroves.contains(alice))
+    assert.equal(alice_Trove[TroveData.status], 1)
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
 
     // check all other Troves are liquidated
-    assert.equal(bob_Trove[3], 3)
-    assert.equal(carol_Trove[3], 3)
-    assert.equal(dennis_Trove[3], 3)
-    assert.equal(erin_Trove[3], 3)
-    assert.equal(freddy_Trove[3], 3)
+    assert.equal(bob_Trove[TroveData.status], 3)
+    assert.equal(carol_Trove[TroveData.status], 3)
+    assert.equal(dennis_Trove[TroveData.status], 3)
+    assert.equal(erin_Trove[TroveData.status], 3)
+    assert.equal(freddy_Trove[TroveData.status], 3)
 
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
-    assert.isFalse(await sortedTroves.contains(dennis))
-    assert.isFalse(await sortedTroves.contains(erin))
-    assert.isFalse(await sortedTroves.contains(freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, erin))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
   })
 
   it('liquidateTroves(): liquidates only up to the requested number of undercollateralized troves', async () => {
-    await openTrove({ ICR: toBN(dec(300, 16)), extraParams: { from: whale, value: dec(300, 'ether') } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraParams: { from: whale, value: dec(300, 'ether') } })
 
     // --- SETUP --- 
     // Alice, Bob, Carol, Dennis, Erin open troves with consecutively increasing collateral ratio
-    await openTrove({ ICR: toBN(dec(210, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(212, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(214, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(216, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(218, 16)), extraParams: { from: erin } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(212, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(214, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(216, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(218, 16)), extraParams: { from: erin } })
 
     await priceFeed.setPrice(dec(100, 18))
 
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     assert.isTrue(TCR.lte(web3.utils.toBN(dec(150, 18))))
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // --- TEST --- 
 
     // Price drops
     await priceFeed.setPrice(dec(100, 18))
 
-    await troveManager.liquidateTroves(3)
+    await troveManager.liquidateTroves(assetAddress1, 3)
 
     // Check system still in Recovery Mode after liquidation tx
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const TroveOwnersArrayLength = await troveManager.getTroveOwnersCount()
+    const TroveOwnersArrayLength = await troveManager.getTroveOwnersCount(assetAddress1)
     assert.equal(TroveOwnersArrayLength, '3')
 
     // Check Alice, Bob, Carol troves have been closed
-    const aliceTroveStatus = (await troveManager.getTroveStatus(alice)).toString()
-    const bobTroveStatus = (await troveManager.getTroveStatus(bob)).toString()
-    const carolTroveStatus = (await troveManager.getTroveStatus(carol)).toString()
+    const aliceTroveStatus = (await troveManager.getTroveStatus(assetAddress1, alice)).toString()
+    const bobTroveStatus = (await troveManager.getTroveStatus(assetAddress1, bob)).toString()
+    const carolTroveStatus = (await troveManager.getTroveStatus(assetAddress1, carol)).toString()
 
     assert.equal(aliceTroveStatus, '3')
     assert.equal(bobTroveStatus, '3')
     assert.equal(carolTroveStatus, '3')
 
     //  Check Alice, Bob, and Carol's trove are no longer in the sorted list
-    const alice_isInSortedList = await sortedTroves.contains(alice)
-    const bob_isInSortedList = await sortedTroves.contains(bob)
-    const carol_isInSortedList = await sortedTroves.contains(carol)
+    const alice_isInSortedList = await sortedTroves.contains(assetAddress1, alice)
+    const bob_isInSortedList = await sortedTroves.contains(assetAddress1, bob)
+    const carol_isInSortedList = await sortedTroves.contains(assetAddress1, carol)
 
     assert.isFalse(alice_isInSortedList)
     assert.isFalse(bob_isInSortedList)
     assert.isFalse(carol_isInSortedList)
 
     // Check Dennis, Erin still have active troves
-    const dennisTroveStatus = (await troveManager.getTroveStatus(dennis)).toString()
-    const erinTroveStatus = (await troveManager.getTroveStatus(erin)).toString()
+    const dennisTroveStatus = (await troveManager.getTroveStatus(assetAddress1, dennis)).toString()
+    const erinTroveStatus = (await troveManager.getTroveStatus(assetAddress1, erin)).toString()
 
     assert.equal(dennisTroveStatus, '1')
     assert.equal(erinTroveStatus, '1')
 
     // Check Dennis, Erin still in sorted list
-    const dennis_isInSortedList = await sortedTroves.contains(dennis)
-    const erin_isInSortedList = await sortedTroves.contains(erin)
+    const dennis_isInSortedList = await sortedTroves.contains(assetAddress1, dennis)
+    const erin_isInSortedList = await sortedTroves.contains(assetAddress1, erin)
 
     assert.isTrue(dennis_isInSortedList)
     assert.isTrue(erin_isInSortedList)
   })
 
   it("liquidateTroves(): does nothing if n = 0", async () => {
-    await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(100, 18), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(200, 18), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(300, 18), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(100, 18), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(200, 18), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(300, 18), extraParams: { from: carol } })
 
     await priceFeed.setPrice(dec(100, 18))
     const price = await priceFeed.getPrice()
 
-    const TCR_Before = (await th.getTCR(contracts)).toString()
+    const TCR_Before = (await th.getTCR(contracts, assetAddress1)).toString()
 
     // Confirm A, B, C ICRs are below 110%
 
-    const alice_ICR = await troveManager.getCurrentICR(alice, price)
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
-    const carol_ICR = await troveManager.getCurrentICR(carol, price)
+    const alice_ICR = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const carol_ICR = await troveManager.getCurrentICR(assetAddress1, carol, price)
     assert.isTrue(alice_ICR.lte(mv._MCR))
     assert.isTrue(bob_ICR.lte(mv._MCR))
     assert.isTrue(carol_ICR.lte(mv._MCR))
 
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Liquidation with n = 0
-    await assertRevert(troveManager.liquidateTroves(0), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidateTroves(assetAddress1, 0), "TroveManager: nothing to liquidate")
 
     // Check all troves are still in the system
-    assert.isTrue(await sortedTroves.contains(alice))
-    assert.isTrue(await sortedTroves.contains(bob))
-    assert.isTrue(await sortedTroves.contains(carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, bob))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
 
-    const TCR_After = (await th.getTCR(contracts)).toString()
+    const TCR_After = (await th.getTCR(contracts, assetAddress1)).toString()
 
     // Check TCR has not changed after liquidation
     assert.equal(TCR_Before, TCR_After)
@@ -2047,14 +2061,14 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
   it('liquidateTroves(): closes every Trove with ICR < MCR, when n > number of undercollateralized troves', async () => {
     // --- SETUP --- 
-    await openTrove({ ICR: toBN(dec(300, 16)), extraParams: { from: whale, value: dec(300, 'ether') } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraParams: { from: whale, value: dec(300, 'ether') } })
 
     // create 5 Troves with varying ICRs
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(133, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(300, 18), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(182, 16)), extraParams: { from: erin } })
-    await openTrove({ ICR: toBN(dec(111, 16)), extraParams: { from: freddy } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(133, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(300, 18), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(182, 16)), extraParams: { from: erin } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(111, 16)), extraParams: { from: freddy } })
 
     // Whale puts some tokens in Stability Pool
     await stabilityPool.provideToSP(dec(300, 18), ZERO_ADDRESS, { from: whale })
@@ -2066,113 +2080,113 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Confirm troves A-E are ICR < 110%
-    assert.isTrue((await troveManager.getCurrentICR(alice, price)).lte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(bob, price)).lte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(carol, price)).lte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(erin, price)).lte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(freddy, price)).lte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, alice, price)).lte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, bob, price)).lte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, carol, price)).lte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, erin, price)).lte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, freddy, price)).lte(mv._MCR))
 
     // Confirm Whale is ICR > 110% 
-    assert.isTrue((await troveManager.getCurrentICR(whale, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, whale, price)).gte(mv._MCR))
 
     // Liquidate 5 troves
-    await troveManager.liquidateTroves(5);
+    await troveManager.liquidateTroves(assetAddress1, 5);
 
     // Confirm troves A-E have been removed from the system
-    assert.isFalse(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
-    assert.isFalse(await sortedTroves.contains(erin))
-    assert.isFalse(await sortedTroves.contains(freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, erin))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
 
     // Check all troves are now liquidated
-    assert.equal((await troveManager.Troves(alice))[3].toString(), '3')
-    assert.equal((await troveManager.Troves(bob))[3].toString(), '3')
-    assert.equal((await troveManager.Troves(carol))[3].toString(), '3')
-    assert.equal((await troveManager.Troves(erin))[3].toString(), '3')
-    assert.equal((await troveManager.Troves(freddy))[3].toString(), '3')
+    assert.equal((await troveManager.Troves(alice, assetAddress1))[TroveData.status].toString(), '3')
+    assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status].toString(), '3')
+    assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status].toString(), '3')
+    assert.equal((await troveManager.Troves(erin, assetAddress1))[TroveData.status].toString(), '3')
+    assert.equal((await troveManager.Troves(freddy, assetAddress1))[TroveData.status].toString(), '3')
   })
 
   it("liquidateTroves(): a liquidation sequence containing Pool offsets increases the TCR", async () => {
     // Whale provides 500 KUSD to SP
-    await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(500, 18), extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(500, 18), extraParams: { from: whale } })
     await stabilityPool.provideToSP(dec(500, 18), ZERO_ADDRESS, { from: whale })
 
-    await openTrove({ ICR: toBN(dec(300, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(320, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(340, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(320, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(340, 16)), extraParams: { from: dennis } })
 
-    await openTrove({ ICR: toBN(dec(198, 16)), extraKUSDAmount: dec(101, 18), extraParams: { from: defaulter_1 } })
-    await openTrove({ ICR: toBN(dec(184, 16)), extraKUSDAmount: dec(217, 18), extraParams: { from: defaulter_2 } })
-    await openTrove({ ICR: toBN(dec(183, 16)), extraKUSDAmount: dec(328, 18), extraParams: { from: defaulter_3 } })
-    await openTrove({ ICR: toBN(dec(186, 16)), extraKUSDAmount: dec(431, 18), extraParams: { from: defaulter_4 } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraKUSDAmount: dec(101, 18), extraParams: { from: defaulter_1 } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(184, 16)), extraKUSDAmount: dec(217, 18), extraParams: { from: defaulter_2 } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(183, 16)), extraKUSDAmount: dec(328, 18), extraParams: { from: defaulter_3 } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(186, 16)), extraKUSDAmount: dec(431, 18), extraParams: { from: defaulter_4 } })
 
-    assert.isTrue((await sortedTroves.contains(defaulter_1)))
-    assert.isTrue((await sortedTroves.contains(defaulter_2)))
-    assert.isTrue((await sortedTroves.contains(defaulter_3)))
-    assert.isTrue((await sortedTroves.contains(defaulter_4)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, defaulter_1)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, defaulter_2)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, defaulter_3)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, defaulter_4)))
 
 
     // Price drops
     await priceFeed.setPrice(dec(110, 18))
     const price = await priceFeed.getPrice()
 
-    assert.isTrue(await th.ICRbetween100and110(defaulter_1, troveManager, price))
-    assert.isTrue(await th.ICRbetween100and110(defaulter_2, troveManager, price))
-    assert.isTrue(await th.ICRbetween100and110(defaulter_3, troveManager, price))
-    assert.isTrue(await th.ICRbetween100and110(defaulter_4, troveManager, price))
+    assert.isTrue(await th.ICRbetween100and110(assetAddress1, defaulter_1, troveManager, price))
+    assert.isTrue(await th.ICRbetween100and110(assetAddress1, defaulter_2, troveManager, price))
+    assert.isTrue(await th.ICRbetween100and110(assetAddress1, defaulter_3, troveManager, price))
+    assert.isTrue(await th.ICRbetween100and110(assetAddress1, defaulter_4, troveManager, price))
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const TCR_Before = await th.getTCR(contracts)
+    const TCR_Before = await th.getTCR(contracts, assetAddress1)
 
     // Check Stability Pool has 500 KUSD
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), dec(500, 18))
 
-    await troveManager.liquidateTroves(8)
+    await troveManager.liquidateTroves(assetAddress1, 8)
 
-    // assert.isFalse((await sortedTroves.contains(defaulter_1)))
-    // assert.isFalse((await sortedTroves.contains(defaulter_2)))
-    // assert.isFalse((await sortedTroves.contains(defaulter_3)))
-    assert.isFalse((await sortedTroves.contains(defaulter_4)))
+    // assert.isFalse((await sortedTroves.contains(assetAddress1, defaulter_1)))
+    // assert.isFalse((await sortedTroves.contains(assetAddress1, defaulter_2)))
+    // assert.isFalse((await sortedTroves.contains(assetAddress1, defaulter_3)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, defaulter_4)))
 
     // Check Stability Pool has been emptied by the liquidations
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), '0')
 
     // Check that the liquidation sequence has improved the TCR
-    const TCR_After = await th.getTCR(contracts)
+    const TCR_After = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_After.gte(TCR_Before))
   })
 
   it("liquidateTroves(): A liquidation sequence of pure redistributions decreases the TCR, due to gas compensation, but up to 0.5%", async () => {
-    const { collateral: W_coll, totalDebt: W_totalDebt } = await openTrove({ ICR: toBN(dec(250, 16)), extraKUSDAmount: dec(500, 18), extraParams: { from: whale } })
+    const { collateral: W_coll, totalDebt: W_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraKUSDAmount: dec(500, 18), extraParams: { from: whale } })
 
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(300, 16)), extraParams: { from: alice } })
-    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(400, 16)), extraParams: { from: carol } })
-    const { collateral: D_coll, totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(600, 16)), extraParams: { from: dennis } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraParams: { from: alice } })
+    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(400, 16)), extraParams: { from: carol } })
+    const { collateral: D_coll, totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(600, 16)), extraParams: { from: dennis } })
 
-    const { collateral: d1_coll, totalDebt: d1_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraKUSDAmount: dec(101, 18), extraParams: { from: defaulter_1 } })
-    const { collateral: d2_coll, totalDebt: d2_totalDebt } = await openTrove({ ICR: toBN(dec(184, 16)), extraKUSDAmount: dec(217, 18), extraParams: { from: defaulter_2 } })
-    const { collateral: d3_coll, totalDebt: d3_totalDebt } = await openTrove({ ICR: toBN(dec(183, 16)), extraKUSDAmount: dec(328, 18), extraParams: { from: defaulter_3 } })
-    const { collateral: d4_coll, totalDebt: d4_totalDebt } = await openTrove({ ICR: toBN(dec(166, 16)), extraKUSDAmount: dec(431, 18), extraParams: { from: defaulter_4 } })
+    const { collateral: d1_coll, totalDebt: d1_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraKUSDAmount: dec(101, 18), extraParams: { from: defaulter_1 } })
+    const { collateral: d2_coll, totalDebt: d2_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(184, 16)), extraKUSDAmount: dec(217, 18), extraParams: { from: defaulter_2 } })
+    const { collateral: d3_coll, totalDebt: d3_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(183, 16)), extraKUSDAmount: dec(328, 18), extraParams: { from: defaulter_3 } })
+    const { collateral: d4_coll, totalDebt: d4_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(166, 16)), extraKUSDAmount: dec(431, 18), extraParams: { from: defaulter_4 } })
 
-    assert.isTrue((await sortedTroves.contains(defaulter_1)))
-    assert.isTrue((await sortedTroves.contains(defaulter_2)))
-    assert.isTrue((await sortedTroves.contains(defaulter_3)))
-    assert.isTrue((await sortedTroves.contains(defaulter_4)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, defaulter_1)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, defaulter_2)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, defaulter_3)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, defaulter_4)))
 
     // Price drops
     const price = toBN(dec(100, 18))
     await priceFeed.setPrice(price)
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const TCR_Before = await th.getTCR(contracts)
+    const TCR_Before = await th.getTCR(contracts, assetAddress1)
     // (5+1+2+3+1+2+3+4)*100/(410+50+50+50+101+257+328+480)
     const totalCollBefore = W_coll.add(A_coll).add(C_coll).add(D_coll).add(d1_coll).add(d2_coll).add(d3_coll).add(d4_coll)
     const totalDebtBefore = W_totalDebt.add(A_totalDebt).add(C_totalDebt).add(D_totalDebt).add(d1_totalDebt).add(d2_totalDebt).add(d3_totalDebt).add(d4_totalDebt)
@@ -2182,16 +2196,16 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), '0')
 
     // Liquidate
-    await troveManager.liquidateTroves(8)
+    await troveManager.liquidateTroves(assetAddress1, 8)
 
     // Check all defaulters have been liquidated
-    assert.isFalse((await sortedTroves.contains(defaulter_1)))
-    assert.isFalse((await sortedTroves.contains(defaulter_2)))
-    assert.isFalse((await sortedTroves.contains(defaulter_3)))
-    assert.isFalse((await sortedTroves.contains(defaulter_4)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, defaulter_1)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, defaulter_2)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, defaulter_3)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, defaulter_4)))
 
     // Check that the liquidation sequence has reduced the TCR
-    const TCR_After = await th.getTCR(contracts)
+    const TCR_After = await th.getTCR(contracts, assetAddress1)
     // ((5+1+2+3)+(1+2+3+4)*0.995)*100/(410+50+50+50+101+257+328+480)
     const totalCollAfter = W_coll.add(A_coll).add(C_coll).add(D_coll).add(th.applyLiquidationFee(d1_coll.add(d2_coll).add(d3_coll).add(d4_coll)))
     const totalDebtAfter = W_totalDebt.add(A_totalDebt).add(C_totalDebt).add(D_totalDebt).add(d1_totalDebt).add(d2_totalDebt).add(d3_totalDebt).add(d4_totalDebt)
@@ -2201,23 +2215,23 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   })
 
   it("liquidateTroves(): liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
-    await openTrove({ ICR: toBN(dec(400, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(220, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(400, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
 
     // Defaulter opens with 60 KUSD, 0.6 ETH
-    await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: defaulter_1 } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: defaulter_1 } })
 
     // Price drops
     await priceFeed.setPrice(dec(100, 18))
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const alice_ICR_Before = await troveManager.getCurrentICR(alice, price)
-    const bob_ICR_Before = await troveManager.getCurrentICR(bob, price)
-    const carol_ICR_Before = await troveManager.getCurrentICR(carol, price)
+    const alice_ICR_Before = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const bob_ICR_Before = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const carol_ICR_Before = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     /* Before liquidation: 
     Alice ICR: = (1 * 100 / 50) = 200%
@@ -2230,11 +2244,11 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.isTrue(carol_ICR_Before.lte(mv._MCR))
 
     // Liquidate defaulter. 30 KUSD and 0.3 ETH is distributed uniformly between A, B and C. Each receive 10 KUSD, 0.1 ETH
-    await troveManager.liquidate(defaulter_1)
+    await troveManager.liquidate(assetAddress1, defaulter_1)
 
-    const alice_ICR_After = await troveManager.getCurrentICR(alice, price)
-    const bob_ICR_After = await troveManager.getCurrentICR(bob, price)
-    const carol_ICR_After = await troveManager.getCurrentICR(carol, price)
+    const alice_ICR_After = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const bob_ICR_After = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const carol_ICR_After = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     /* After liquidation: 
 
@@ -2249,65 +2263,65 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     /* Though Bob's true ICR (including pending rewards) is below the MCR, 
    check that Bob's raw coll and debt has not changed, and that his "raw" ICR is above the MCR */
-    const bob_Coll = (await troveManager.Troves(bob))[1]
-    const bob_Debt = (await troveManager.Troves(bob))[0]
+    const bob_Coll = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const bob_Debt = (await troveManager.Troves(bob, assetAddress1))[TroveData.debt]
 
     const bob_rawICR = bob_Coll.mul(th.toBN(dec(100, 18))).div(bob_Debt)
     assert.isTrue(bob_rawICR.gte(mv._MCR))
 
     // Liquidate A, B, C
-    await troveManager.liquidateTroves(10)
+    await troveManager.liquidateTroves(assetAddress1, 10)
 
     /*  Since there is 0 KUSD in the stability Pool, A, with ICR >110%, should stay active.
    Check Alice stays active, Carol gets liquidated, and Bob gets liquidated 
    (because his pending rewards bring his ICR < MCR) */
-    assert.isTrue(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
 
     // check trove statuses - A active (1),  B and C liquidated (3)
-    assert.equal((await troveManager.Troves(alice))[3].toString(), '1')
-    assert.equal((await troveManager.Troves(bob))[3].toString(), '3')
-    assert.equal((await troveManager.Troves(carol))[3].toString(), '3')
+    assert.equal((await troveManager.Troves(alice, assetAddress1))[TroveData.status].toString(), '1')
+    assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status].toString(), '3')
+    assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status].toString(), '3')
   })
 
   it('liquidateTroves(): does nothing if all troves have ICR > 110% and Stability Pool is empty', async () => {
-    await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(250, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
 
     // Price drops, but all troves remain active
     await priceFeed.setPrice(dec(100, 18))
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    assert.isTrue((await sortedTroves.contains(alice)))
-    assert.isTrue((await sortedTroves.contains(bob)))
-    assert.isTrue((await sortedTroves.contains(carol)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, alice)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, bob)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, carol)))
 
-    const TCR_Before = (await th.getTCR(contracts)).toString()
-    const listSize_Before = (await sortedTroves.getSize()).toString()
+    const TCR_Before = (await th.getTCR(contracts, assetAddress1)).toString()
+    const listSize_Before = (await sortedTroves.getSize(assetAddress1)).toString()
 
 
-    assert.isTrue((await troveManager.getCurrentICR(alice, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(bob, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(carol, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, alice, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, bob, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, carol, price)).gte(mv._MCR))
 
     // Confirm 0 KUSD in Stability Pool
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), '0')
 
     // Attempt liqudation sequence
-    await assertRevert(troveManager.liquidateTroves(10), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.liquidateTroves(assetAddress1, 10), "TroveManager: nothing to liquidate")
 
     // Check all troves remain active
-    assert.isTrue((await sortedTroves.contains(alice)))
-    assert.isTrue((await sortedTroves.contains(bob)))
-    assert.isTrue((await sortedTroves.contains(carol)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, alice)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, bob)))
+    assert.isTrue((await sortedTroves.contains(assetAddress1, carol)))
 
-    const TCR_After = (await th.getTCR(contracts)).toString()
-    const listSize_After = (await sortedTroves.getSize()).toString()
+    const TCR_After = (await th.getTCR(contracts, assetAddress1)).toString()
+    const listSize_After = (await sortedTroves.getSize(assetAddress1)).toString()
 
     assert.equal(TCR_Before, TCR_After)
     assert.equal(listSize_Before, listSize_After)
@@ -2315,18 +2329,18 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
   it('liquidateTroves(): emits liquidation event with correct values when all troves have ICR > 110% and Stability Pool covers a subset of troves', async () => {
     // Troves to be absorbed by SP
-    const { collateral: F_coll, totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: freddy } })
-    const { collateral: G_coll, totalDebt: G_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: greta } })
+    const { collateral: F_coll, totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: freddy } })
+    const { collateral: G_coll, totalDebt: G_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: greta } })
 
     // Troves to be spared
-    await openTrove({ ICR: toBN(dec(250, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(266, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(308, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(308, 16)), extraParams: { from: dennis } })
 
     // Whale adds KUSD to SP
     const spDeposit = F_totalDebt.add(G_totalDebt)
-    await openTrove({ ICR: toBN(dec(285, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops, but all troves remain active
@@ -2334,32 +2348,32 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Confirm all troves have ICR > MCR
-    assert.isTrue((await troveManager.getCurrentICR(freddy, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(greta, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(alice, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(bob, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(carol, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, freddy, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, greta, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, alice, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, bob, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, carol, price)).gte(mv._MCR))
 
     // Confirm KUSD in Stability Pool
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), spDeposit.toString())
 
     // Attempt liqudation sequence
-    const liquidationTx = await troveManager.liquidateTroves(10)
+    const liquidationTx = await troveManager.liquidateTroves(assetAddress1, 10)
     const [liquidatedDebt, liquidatedColl, gasComp] = th.getEmittedLiquidationValues(liquidationTx)
 
     // Check F and G were liquidated
-    assert.isFalse(await sortedTroves.contains(freddy))
-    assert.isFalse(await sortedTroves.contains(greta))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, greta))
 
     // Check whale and A-D remain active
-    assert.isTrue(await sortedTroves.contains(alice))
-    assert.isTrue(await sortedTroves.contains(bob))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(dennis))
-    assert.isTrue(await sortedTroves.contains(whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, bob))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
 
     // Liquidation event emits coll = (F_debt + G_debt)/price*1.1*0.995, and debt = (F_debt + G_debt)
     th.assertIsApproximatelyEqual(liquidatedDebt, F_totalDebt.add(G_totalDebt))
@@ -2368,37 +2382,35 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // check collateral surplus
     const freddy_remainingCollateral = F_coll.sub(F_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
     const greta_remainingCollateral = G_coll.sub(G_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(freddy), freddy_remainingCollateral)
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(greta), greta_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, freddy), freddy_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, greta), greta_remainingCollateral)
 
     // can claim collateral
-    const freddy_balanceBefore = th.toBN(await web3.eth.getBalance(freddy))
-    const FREDDY_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: freddy, gasPrice: GAS_PRICE  }))
-    const freddy_expectedBalance = freddy_balanceBefore.sub(th.toBN(FREDDY_GAS * GAS_PRICE))
-    const freddy_balanceAfter = th.toBN(await web3.eth.getBalance(freddy))
-    th.assertIsApproximatelyEqual(freddy_balanceAfter, freddy_expectedBalance.add(th.toBN(freddy_remainingCollateral)))
+    const freddy_balanceBefore = th.toBN(await erc20Asset1.balanceOf(freddy))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: freddy, gasPrice: GAS_PRICE })
+    const freddy_balanceAfter = th.toBN(await erc20Asset1.balanceOf(freddy))
+    th.assertIsApproximatelyEqual(freddy_balanceAfter, freddy_balanceBefore.add(th.toBN(freddy_remainingCollateral)))
 
-    const greta_balanceBefore = th.toBN(await web3.eth.getBalance(greta))
-    const GRETA_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: greta, gasPrice: GAS_PRICE  }))
-    const greta_expectedBalance = greta_balanceBefore.sub(th.toBN(GRETA_GAS * GAS_PRICE))
-    const greta_balanceAfter = th.toBN(await web3.eth.getBalance(greta))
-    th.assertIsApproximatelyEqual(greta_balanceAfter, greta_expectedBalance.add(th.toBN(greta_remainingCollateral)))
+    const greta_balanceBefore = th.toBN(await erc20Asset1.balanceOf(greta))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: greta, gasPrice: GAS_PRICE })
+    const greta_balanceAfter = th.toBN(await erc20Asset1.balanceOf(greta))
+    th.assertIsApproximatelyEqual(greta_balanceAfter, greta_balanceBefore.add(th.toBN(greta_remainingCollateral)))
   })
 
   it('liquidateTroves():  emits liquidation event with correct values when all troves have ICR > 110% and Stability Pool covers a subset of troves, including a partial', async () => {
     // Troves to be absorbed by SP
-    const { collateral: F_coll, totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: freddy } })
-    const { collateral: G_coll, totalDebt: G_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: greta } })
+    const { collateral: F_coll, totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: freddy } })
+    const { collateral: G_coll, totalDebt: G_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: greta } })
 
     // Troves to be spared
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(250, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(266, 16)), extraParams: { from: bob } })
-    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
-    const { collateral: D_coll, totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(308, 16)), extraParams: { from: dennis } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraParams: { from: bob } })
+    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
+    const { collateral: D_coll, totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(308, 16)), extraParams: { from: dennis } })
 
     // Whale adds KUSD to SP
     const spDeposit = F_totalDebt.add(G_totalDebt).add(A_totalDebt.div(toBN(2)))
-    const { collateral: W_coll, totalDebt: W_totalDebt } = await openTrove({ ICR: toBN(dec(285, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    const { collateral: W_coll, totalDebt: W_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops, but all troves remain active
@@ -2406,36 +2418,36 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Confirm all troves have ICR > MCR
-    assert.isTrue((await troveManager.getCurrentICR(freddy, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(greta, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(alice, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(bob, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(carol, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, freddy, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, greta, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, alice, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, bob, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, carol, price)).gte(mv._MCR))
 
     // Confirm KUSD in Stability Pool
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), spDeposit.toString())
 
     // Attempt liqudation sequence
-    const liquidationTx = await troveManager.liquidateTroves(10)
+    const liquidationTx = await troveManager.liquidateTroves(assetAddress1, 10)
     const [liquidatedDebt, liquidatedColl, gasComp] = th.getEmittedLiquidationValues(liquidationTx)
 
     // Check F and G were liquidated
-    assert.isFalse(await sortedTroves.contains(freddy))
-    assert.isFalse(await sortedTroves.contains(greta))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, greta))
 
     // Check whale and A-D remain active
-    assert.isTrue(await sortedTroves.contains(alice))
-    assert.isTrue(await sortedTroves.contains(bob))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(dennis))
-    assert.isTrue(await sortedTroves.contains(whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, bob))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
 
     // Check A's collateral and debt remain the same
-    const entireColl_A = (await troveManager.Troves(alice))[1].add(await troveManager.getPendingETHReward(alice))
-    const entireDebt_A = (await troveManager.Troves(alice))[0].add(await troveManager.getPendingKUSDDebtReward(alice))
+    const entireColl_A = (await troveManager.Troves(alice, assetAddress1))[TroveData.coll].add(await troveManager.getPendingReward(assetAddress1, alice))
+    const entireDebt_A = (await troveManager.Troves(alice, assetAddress1))[TroveData.debt].add(await troveManager.getPendingKUSDDebtReward(assetAddress1, alice))
 
     assert.equal(entireColl_A.toString(), A_coll)
     assert.equal(entireDebt_A.toString(), A_totalDebt)
@@ -2449,33 +2461,31 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // check collateral surplus
     const freddy_remainingCollateral = F_coll.sub(F_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
     const greta_remainingCollateral = G_coll.sub(G_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(freddy), freddy_remainingCollateral)
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(greta), greta_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, freddy), freddy_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, greta), greta_remainingCollateral)
 
     // can claim collateral
-    const freddy_balanceBefore = th.toBN(await web3.eth.getBalance(freddy))
-    const FREDDY_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: freddy, gasPrice: GAS_PRICE  }))
-    const freddy_expectedBalance = freddy_balanceBefore.sub(th.toBN(FREDDY_GAS * GAS_PRICE))
-    const freddy_balanceAfter = th.toBN(await web3.eth.getBalance(freddy))
-    th.assertIsApproximatelyEqual(freddy_balanceAfter, freddy_expectedBalance.add(th.toBN(freddy_remainingCollateral)))
+    const freddy_balanceBefore = th.toBN(await erc20Asset1.balanceOf(freddy))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: freddy, gasPrice: GAS_PRICE })
+    const freddy_balanceAfter = th.toBN(await erc20Asset1.balanceOf(freddy))
+    th.assertIsApproximatelyEqual(freddy_balanceAfter, freddy_balanceBefore.add(th.toBN(freddy_remainingCollateral)))
 
-    const greta_balanceBefore = th.toBN(await web3.eth.getBalance(greta))
-    const GRETA_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: greta, gasPrice: GAS_PRICE  }))
-    const greta_expectedBalance = greta_balanceBefore.sub(th.toBN(GRETA_GAS * GAS_PRICE))
-    const greta_balanceAfter = th.toBN(await web3.eth.getBalance(greta))
-    th.assertIsApproximatelyEqual(greta_balanceAfter, greta_expectedBalance.add(th.toBN(greta_remainingCollateral)))
+    const greta_balanceBefore = th.toBN(await erc20Asset1.balanceOf(greta))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: greta, gasPrice: GAS_PRICE })
+    const greta_balanceAfter = th.toBN(await erc20Asset1.balanceOf(greta))
+    th.assertIsApproximatelyEqual(greta_balanceAfter, greta_balanceBefore.add(th.toBN(greta_remainingCollateral)))
   })
 
   it("liquidateTroves(): does not affect the liquidated user's token balances", async () => {
-    await openTrove({ ICR: toBN(dec(300, 16)), extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraParams: { from: whale } })
 
     // D, E, F open troves that will fall below MCR when price drops to 100
-    const { kusdAmount: kusdAmountD } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: dennis } })
-    const { kusdAmount: kusdAmountE } = await openTrove({ ICR: toBN(dec(133, 16)), extraParams: { from: erin } })
-    const { kusdAmount: kusdAmountF } = await openTrove({ ICR: toBN(dec(111, 16)), extraParams: { from: freddy } })
+    const { kusdAmount: kusdAmountD } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: dennis } })
+    const { kusdAmount: kusdAmountE } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(133, 16)), extraParams: { from: erin } })
+    const { kusdAmount: kusdAmountF } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(111, 16)), extraParams: { from: freddy } })
 
     // Check list size is 4
-    assert.equal((await sortedTroves.getSize()).toString(), '4')
+    assert.equal((await sortedTroves.getSize(assetAddress1)).toString(), '4')
 
     // Check token balances before
     assert.equal((await kusdToken.balanceOf(dennis)).toString(), kusdAmountD)
@@ -2486,18 +2496,18 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await priceFeed.setPrice(dec(100, 18))
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     //Liquidate sequence
-    await troveManager.liquidateTroves(10)
+    await troveManager.liquidateTroves(assetAddress1, 10)
 
     // Check Whale remains in the system
-    assert.isTrue(await sortedTroves.contains(whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
 
     // Check D, E, F have been removed
-    assert.isFalse(await sortedTroves.contains(dennis))
-    assert.isFalse(await sortedTroves.contains(erin))
-    assert.isFalse(await sortedTroves.contains(freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, erin))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
 
     // Check token balances of users whose troves were liquidated, have not changed
     assert.equal((await kusdToken.balanceOf(dennis)).toString(), kusdAmountD)
@@ -2507,12 +2517,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
   it("liquidateTroves(): Liquidating troves at 100 < ICR < 110 with SP deposits correctly impacts their SP deposit and ETH gain", async () => {
     // Whale provides KUSD to the SP
-    const { kusdAmount: W_kusdAmount } = await openTrove({ ICR: toBN(dec(300, 16)), extraKUSDAmount: dec(4000, 18), extraParams: { from: whale } })
+    const { kusdAmount: W_kusdAmount } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraKUSDAmount: dec(4000, 18), extraParams: { from: whale } })
     await stabilityPool.provideToSP(W_kusdAmount, ZERO_ADDRESS, { from: whale })
 
-    const { kusdAmount: A_kusdAmount, totalDebt: A_totalDebt, collateral: A_coll } = await openTrove({ ICR: toBN(dec(191, 16)), extraKUSDAmount: dec(40, 18), extraParams: { from: alice } })
-    const { kusdAmount: B_kusdAmount, totalDebt: B_totalDebt, collateral: B_coll } = await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(240, 18), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt, collateral: C_coll} = await openTrove({ ICR: toBN(dec(209, 16)), extraParams: { from: carol } })
+    const { kusdAmount: A_kusdAmount, totalDebt: A_totalDebt, collateral: A_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(191, 16)), extraKUSDAmount: dec(40, 18), extraParams: { from: alice } })
+    const { kusdAmount: B_kusdAmount, totalDebt: B_totalDebt, collateral: B_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: dec(240, 18), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt, collateral: C_coll } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(209, 16)), extraParams: { from: carol } })
 
     // A, B provide to the SP
     await stabilityPool.provideToSP(A_kusdAmount, ZERO_ADDRESS, { from: alice })
@@ -2520,37 +2530,37 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     const totalDeposit = W_kusdAmount.add(A_kusdAmount).add(B_kusdAmount)
 
-    assert.equal((await sortedTroves.getSize()).toString(), '4')
+    assert.equal((await sortedTroves.getSize(assetAddress1)).toString(), '4')
 
     // Price drops
     await priceFeed.setPrice(dec(105, 18))
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check KUSD in Pool
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), totalDeposit)
 
     // *** Check A, B, C ICRs 100<ICR<110
-    const alice_ICR = await troveManager.getCurrentICR(alice, price)
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
-    const carol_ICR = await troveManager.getCurrentICR(carol, price)
+    const alice_ICR = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const carol_ICR = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(alice_ICR.gte(mv._ICR100) && alice_ICR.lte(mv._MCR))
     assert.isTrue(bob_ICR.gte(mv._ICR100) && bob_ICR.lte(mv._MCR))
     assert.isTrue(carol_ICR.gte(mv._ICR100) && carol_ICR.lte(mv._MCR))
 
     // Liquidate
-    await troveManager.liquidateTroves(10)
+    await troveManager.liquidateTroves(assetAddress1, 10)
 
     // Check all defaulters have been liquidated
-    assert.isFalse((await sortedTroves.contains(alice)))
-    assert.isFalse((await sortedTroves.contains(bob)))
-    assert.isFalse((await sortedTroves.contains(carol)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, alice)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, bob)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, carol)))
 
     // check system sized reduced to 1 troves
-    assert.equal((await sortedTroves.getSize()).toString(), '1')
+    assert.equal((await sortedTroves.getSize(assetAddress1)).toString(), '1')
 
     /* Prior to liquidation, SP deposits were:
     Whale: 400 KUSD
@@ -2581,16 +2591,16 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Total ETH gain: 5*0.995 ETH */
 
     const KUSDinSP = (await stabilityPool.getTotalKUSDDeposits()).toString()
-    const ETHinSP = (await stabilityPool.getETH()).toString()
+    const ETHinSP = (await stabilityPool.getAssetBalance()).toString()
 
     // Check remaining KUSD Deposits and ETH gain, for whale and depositors whose troves were liquidated
     const whale_Deposit_After = (await stabilityPool.getCompoundedKUSDDeposit(whale)).toString()
     const alice_Deposit_After = (await stabilityPool.getCompoundedKUSDDeposit(alice)).toString()
     const bob_Deposit_After = (await stabilityPool.getCompoundedKUSDDeposit(bob)).toString()
 
-    const whale_ETHGain = (await stabilityPool.getDepositorETHGain(whale)).toString()
-    const alice_ETHGain = (await stabilityPool.getDepositorETHGain(alice)).toString()
-    const bob_ETHGain = (await stabilityPool.getDepositorETHGain(bob)).toString()
+    const whale_ETHGain = (await stabilityPool.getDepositorAssetGain(whale)).toString()
+    const alice_ETHGain = (await stabilityPool.getDepositorAssetGain(alice)).toString()
+    const bob_ETHGain = (await stabilityPool.getDepositorAssetGain(bob)).toString()
 
     const liquidatedDebt = A_totalDebt.add(B_totalDebt).add(C_totalDebt)
     const liquidatedColl = A_coll.add(B_coll).add(C_coll)
@@ -2604,7 +2614,7 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     // Check total remaining deposits and ETH gain in Stability Pool
     const total_KUSDinSP = (await stabilityPool.getTotalKUSDDeposits()).toString()
-    const total_ETHinSP = (await stabilityPool.getETH()).toString()
+    const total_ETHinSP = (await stabilityPool.getAssetBalance()).toString()
 
     assert.isAtMost(th.getDifference(total_KUSDinSP, totalDeposit.sub(liquidatedDebt)), 1000)
     assert.isAtMost(th.getDifference(total_ETHinSP, th.applyLiquidationFee(liquidatedColl)), 1000)
@@ -2612,51 +2622,51 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
   it("liquidateTroves(): Liquidating troves at ICR <=100% with SP deposits does not alter their deposit or ETH gain", async () => {
     // Whale provides 400 KUSD to the SP
-    await openTrove({ ICR: toBN(dec(300, 16)), extraKUSDAmount: dec(400, 18), extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraKUSDAmount: dec(400, 18), extraParams: { from: whale } })
     await stabilityPool.provideToSP(dec(400, 18), ZERO_ADDRESS, { from: whale })
 
-    await openTrove({ ICR: toBN(dec(182, 16)), extraKUSDAmount: dec(170, 18), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(180, 16)), extraKUSDAmount: dec(300, 18), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(170, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(182, 16)), extraKUSDAmount: dec(170, 18), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(180, 16)), extraKUSDAmount: dec(300, 18), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(170, 16)), extraParams: { from: carol } })
 
     // A, B provide 100, 300 to the SP
     await stabilityPool.provideToSP(dec(100, 18), ZERO_ADDRESS, { from: alice })
     await stabilityPool.provideToSP(dec(300, 18), ZERO_ADDRESS, { from: bob })
 
-    assert.equal((await sortedTroves.getSize()).toString(), '4')
+    assert.equal((await sortedTroves.getSize(assetAddress1)).toString(), '4')
 
     // Price drops
     await priceFeed.setPrice(dec(100, 18))
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check KUSD and ETH in Pool  before
     const KUSDinSP_Before = (await stabilityPool.getTotalKUSDDeposits()).toString()
-    const ETHinSP_Before = (await stabilityPool.getETH()).toString()
+    const ETHinSP_Before = (await stabilityPool.getAssetBalance()).toString()
     assert.equal(KUSDinSP_Before, dec(800, 18))
     assert.equal(ETHinSP_Before, '0')
 
     // *** Check A, B, C ICRs < 100
-    assert.isTrue((await troveManager.getCurrentICR(alice, price)).lte(mv._ICR100))
-    assert.isTrue((await troveManager.getCurrentICR(bob, price)).lte(mv._ICR100))
-    assert.isTrue((await troveManager.getCurrentICR(carol, price)).lte(mv._ICR100))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, alice, price)).lte(mv._ICR100))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, bob, price)).lte(mv._ICR100))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, carol, price)).lte(mv._ICR100))
 
     // Liquidate
-    await troveManager.liquidateTroves(10)
+    await troveManager.liquidateTroves(assetAddress1, 10)
 
     // Check all defaulters have been liquidated
-    assert.isFalse((await sortedTroves.contains(alice)))
-    assert.isFalse((await sortedTroves.contains(bob)))
-    assert.isFalse((await sortedTroves.contains(carol)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, alice)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, bob)))
+    assert.isFalse((await sortedTroves.contains(assetAddress1, carol)))
 
     // check system sized reduced to 1 troves
-    assert.equal((await sortedTroves.getSize()).toString(), '1')
+    assert.equal((await sortedTroves.getSize(assetAddress1)).toString(), '1')
 
     // Check KUSD and ETH in Pool after
     const KUSDinSP_After = (await stabilityPool.getTotalKUSDDeposits()).toString()
-    const ETHinSP_After = (await stabilityPool.getETH()).toString()
+    const ETHinSP_After = (await stabilityPool.getAssetBalance()).toString()
     assert.equal(KUSDinSP_Before, KUSDinSP_After)
     assert.equal(ETHinSP_Before, ETHinSP_After)
 
@@ -2665,9 +2675,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const alice_Deposit_After = (await stabilityPool.getCompoundedKUSDDeposit(alice)).toString()
     const bob_Deposit_After = (await stabilityPool.getCompoundedKUSDDeposit(bob)).toString()
 
-    const whale_ETHGain_After = (await stabilityPool.getDepositorETHGain(whale)).toString()
-    const alice_ETHGain_After = (await stabilityPool.getDepositorETHGain(alice)).toString()
-    const bob_ETHGain_After = (await stabilityPool.getDepositorETHGain(bob)).toString()
+    const whale_ETHGain_After = (await stabilityPool.getDepositorAssetGain(whale)).toString()
+    const alice_ETHGain_After = (await stabilityPool.getDepositorAssetGain(alice)).toString()
+    const bob_ETHGain_After = (await stabilityPool.getDepositorAssetGain(bob)).toString()
 
     assert.equal(whale_Deposit_After, dec(400, 18))
     assert.equal(alice_Deposit_After, dec(100, 18))
@@ -2679,29 +2689,29 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   })
 
   it("liquidateTroves() with a non fullfilled liquidation: non liquidated trove remains active", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(300, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(300, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C, D, E troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -2710,41 +2720,41 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     /* Liquidate troves. Troves are ordered by ICR, from low to high:  A, B, C, D, E.
     With 253 in the SP, Alice (102 debt) and Bob (101 debt) should be entirely liquidated. 
     That leaves 50 KUSD in the Pool to absorb exactly half of Carol's debt (100) */
-    await troveManager.liquidateTroves(10)
+    await troveManager.liquidateTroves(assetAddress1, 10)
 
     // Check A and B closed
-    assert.isFalse(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
 
     // Check C remains active
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.equal((await troveManager.Troves(carol))[3].toString(), '1') // check Status is active
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status].toString(), '1') // check Status is active
   })
 
   it("liquidateTroves() with a non fullfilled liquidation: non liquidated trove remains in TroveOwners Array", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(211, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(212, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(211, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(212, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -2753,15 +2763,15 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     /* Liquidate troves. Troves are ordered by ICR, from low to high:  A, B, C.
     With 253 in the SP, Alice (102 debt) and Bob (101 debt) should be entirely liquidated. 
     That leaves 50 KUSD in the Pool to absorb exactly half of Carol's debt (100) */
-    await troveManager.liquidateTroves(10)
+    await troveManager.liquidateTroves(assetAddress1, 10)
 
     // Check C is in Trove owners array
-    const arrayLength = (await troveManager.getTroveOwnersCount()).toNumber()
+    const arrayLength = (await troveManager.getTroveOwnersCount(assetAddress1)).toNumber()
     let addressFound = false;
     let addressIdx = 0;
 
     for (let i = 0; i < arrayLength; i++) {
-      const address = (await troveManager.TroveOwners(i)).toString()
+      const address = (await troveManager.TroveOwners(assetAddress1, i)).toString()
       if (address == carol) {
         addressFound = true
         addressIdx = i
@@ -2771,36 +2781,36 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.isTrue(addressFound);
 
     // Check TroveOwners idx on trove struct == idx of address found in TroveOwners array
-    const idxOnStruct = (await troveManager.Troves(carol))[4].toString()
+    const idxOnStruct = (await troveManager.Troves(carol, assetAddress1))[TroveData.arrayIndex].toString()
     assert.equal(addressIdx.toString(), idxOnStruct)
   })
 
   it("liquidateTroves() with a non fullfilled liquidation: still can liquidate further troves after the non-liquidated, emptied pool", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: D_totalDebt, extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: D_totalDebt, extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(D_totalDebt)
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C, D, E troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
-    const ICR_D = await troveManager.getCurrentICR(dennis, price)
-    const ICR_E = await troveManager.getCurrentICR(erin, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    const ICR_D = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    const ICR_E = await troveManager.getCurrentICR(assetAddress1, erin, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -2813,47 +2823,46 @@ contract('TroveManager - in Recovery Mode', async accounts => {
      That leaves 97 KUSD in the Pool that won’t be enough to absorb Carol,
      but it will be enough to liquidate Dennis. Afterwards the pool will be empty,
      so Erin won’t liquidated. */
-    const tx = await troveManager.liquidateTroves(10)
-    console.log('gasUsed: ', tx.receipt.gasUsed)
+    const tx = await troveManager.liquidateTroves(assetAddress1, 10)
 
     // Check A, B and D are closed
-    assert.isFalse(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
-    console.log(await sortedTroves.contains(carol))
-    assert.isFalse(await sortedTroves.contains(dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    console.log(await sortedTroves.contains(assetAddress1, carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
 
     // Check whale, C and E stay active
-    assert.isTrue(await sortedTroves.contains(whale))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(erin))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, erin))
   })
 
   it("liquidateTroves() with a non fullfilled liquidation: still can liquidate further troves after the non-liquidated, non emptied pool", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: D_totalDebt, extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: D_totalDebt, extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(D_totalDebt)
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C, D, E troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
-    const ICR_D = await troveManager.getCurrentICR(dennis, price)
-    const ICR_E = await troveManager.getCurrentICR(erin, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    const ICR_D = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    const ICR_E = await troveManager.getCurrentICR(assetAddress1, erin, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -2868,60 +2877,59 @@ contract('TroveManager - in Recovery Mode', async accounts => {
      so Erin won’t liquidated.
      Note that, compared to the previous test, this one will make 1 more loop iteration,
      so it will consume more gas. */
-    const tx = await troveManager.liquidateTroves(10)
-    console.log('gasUsed: ', tx.receipt.gasUsed)
+    const tx = await troveManager.liquidateTroves(assetAddress1, 10)
 
     // Check A, B and D are closed
-    assert.isFalse(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
 
     // Check whale, C and E stay active
-    assert.isTrue(await sortedTroves.contains(whale))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(erin))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, erin))
   })
 
   it("liquidateTroves() with a non fullfilled liquidation: total liquidated coll and debt is correct", async () => {
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))
 
-    const entireSystemCollBefore = await troveManager.getEntireSystemColl()
-    const entireSystemDebtBefore = await troveManager.getEntireSystemDebt()
+    const entireSystemCollBefore = await troveManager.getEntireSystemColl(assetAddress1)
+    const entireSystemDebtBefore = await troveManager.getEntireSystemDebt(assetAddress1)
 
     /* Liquidate troves. Troves are ordered by ICR, from low to high:  A, B, C, D, E.
     With 253 in the SP, Alice (102 debt) and Bob (101 debt) should be entirely liquidated. 
     That leaves 50 KUSD in the Pool that won’t be enough to absorb any other trove */
-    const tx = await troveManager.liquidateTroves(10)
+    const tx = await troveManager.liquidateTroves(assetAddress1, 10)
 
     // Expect system debt reduced by 203 KUSD and system coll 2.3 ETH
-    const entireSystemCollAfter = await troveManager.getEntireSystemColl()
-    const entireSystemDebtAfter = await troveManager.getEntireSystemDebt()
+    const entireSystemCollAfter = await troveManager.getEntireSystemColl(assetAddress1)
+    const entireSystemDebtAfter = await troveManager.getEntireSystemDebt(assetAddress1)
 
     const changeInEntireSystemColl = entireSystemCollBefore.sub(entireSystemCollAfter)
     const changeInEntireSystemDebt = entireSystemDebtBefore.sub(entireSystemDebtAfter)
@@ -2931,29 +2939,29 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   })
 
   it("liquidateTroves() with a non fullfilled liquidation: emits correct liquidation event values", async () => {
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(211, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(212, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(211, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(212, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(240, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -2962,7 +2970,7 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     /* Liquidate troves. Troves are ordered by ICR, from low to high:  A, B, C, D, E.
     With 253 in the SP, Alice (102 debt) and Bob (101 debt) should be entirely liquidated. 
     That leaves 50 KUSD in the Pool which won’t be enough for any other liquidation */
-    const liquidationTx = await troveManager.liquidateTroves(10)
+    const liquidationTx = await troveManager.liquidateTroves(assetAddress1, 10)
 
     const [liquidatedDebt, liquidatedColl, collGasComp, kusdGasComp] = th.getEmittedLiquidationValues(liquidationTx)
 
@@ -2975,45 +2983,45 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // check collateral surplus
     const alice_remainingCollateral = A_coll.sub(A_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
     const bob_remainingCollateral = B_coll.sub(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(alice), alice_remainingCollateral)
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, alice), alice_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_remainingCollateral)
 
     // can claim collateral
-    const alice_balanceBefore = th.toBN(await web3.eth.getBalance(alice))
-    const ALICE_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: alice, gasPrice: GAS_PRICE  }))
-    const alice_balanceAfter = th.toBN(await web3.eth.getBalance(alice))
-    th.assertIsApproximatelyEqual(alice_balanceAfter, alice_balanceBefore.add(th.toBN(alice_remainingCollateral).sub(th.toBN(ALICE_GAS * GAS_PRICE))))
+    const alice_balanceBefore = th.toBN(await erc20Asset1.balanceOf(alice))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: alice, gasPrice: GAS_PRICE })
+    const alice_balanceAfter = th.toBN(await erc20Asset1.balanceOf(alice))
+    th.assertIsApproximatelyEqual(alice_balanceAfter, alice_balanceBefore.add(th.toBN(alice_remainingCollateral)))
 
-    const bob_balanceBefore = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_balanceAfter = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral).sub(th.toBN(BOB_GAS * GAS_PRICE))))
+    const bob_balanceBefore = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral)))
   })
 
   it("liquidateTroves() with a non fullfilled liquidation: ICR of non liquidated trove does not change", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C_Before = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C_Before = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -3022,9 +3030,9 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     /* Liquidate troves. Troves are ordered by ICR, from low to high:  A, B, C, D, E.
     With 253 in the SP, Alice (102 debt) and Bob (101 debt) should be entirely liquidated. 
     That leaves 50 KUSD in the Pool to absorb exactly half of Carol's debt (100) */
-    await troveManager.liquidateTroves(10)
+    await troveManager.liquidateTroves(assetAddress1, 10)
 
-    const ICR_C_After = await troveManager.getCurrentICR(carol, price)
+    const ICR_C_After = await troveManager.getCurrentICR(assetAddress1, carol, price)
     assert.equal(ICR_C_Before.toString(), ICR_C_After)
   })
 
@@ -3035,14 +3043,14 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   it("batchLiquidateTroves(): Liquidates all troves with ICR < 110%, transitioning Normal -> Recovery Mode", async () => {
     // make 6 Troves accordingly
     // --- SETUP ---
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: carol } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(230, 16)), extraParams: { from: dennis } })
-    const { totalDebt: E_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
-    const { totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: carol } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(230, 16)), extraParams: { from: dennis } })
+    const { totalDebt: E_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
+    const { totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
 
     const spDeposit = B_totalDebt.add(C_totalDebt).add(D_totalDebt).add(E_totalDebt).add(F_totalDebt)
-    await openTrove({ ICR: toBN(dec(426, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(426, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
 
     // Alice deposits KUSD to Stability Pool
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: alice })
@@ -3053,12 +3061,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     // check Recovery Mode kicks in
 
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts)
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode_Before)
 
     // check TCR < 150%
     const _150percent = web3.utils.toBN('1500000000000000000')
-    const TCR_Before = await th.getTCR(contracts)
+    const TCR_Before = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_Before.lt(_150percent))
 
     /* 
@@ -3072,12 +3080,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Elisa       102%
     Freddy      102%
     */
-    alice_ICR = await troveManager.getCurrentICR(alice, price)
-    bob_ICR = await troveManager.getCurrentICR(bob, price)
-    carol_ICR = await troveManager.getCurrentICR(carol, price)
-    dennis_ICR = await troveManager.getCurrentICR(dennis, price)
-    erin_ICR = await troveManager.getCurrentICR(erin, price)
-    freddy_ICR = await troveManager.getCurrentICR(freddy, price)
+    alice_ICR = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    carol_ICR = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    dennis_ICR = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    erin_ICR = await troveManager.getCurrentICR(assetAddress1, erin, price)
+    freddy_ICR = await troveManager.getCurrentICR(assetAddress1, freddy, price)
 
     // Alice should have ICR > 150%
     assert.isTrue(alice_ICR.gt(_150percent))
@@ -3094,40 +3102,40 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Only Alice should remain active - all others should be closed. */
 
     // call batchLiquidateTroves
-    await troveManager.batchLiquidateTroves([alice, bob, carol, dennis, erin, freddy]);
+    await troveManager.batchLiquidateTroves(assetAddress1, [alice, bob, carol, dennis, erin, freddy]);
 
     // check system is no longer in Recovery Mode
-    const recoveryMode_After = await th.checkRecoveryMode(contracts)
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isFalse(recoveryMode_After)
 
     // After liquidation, TCR should rise to above 150%. 
-    const TCR_After = await th.getTCR(contracts)
+    const TCR_After = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_After.gt(_150percent))
 
     // get all Troves
-    const alice_Trove = await troveManager.Troves(alice)
-    const bob_Trove = await troveManager.Troves(bob)
-    const carol_Trove = await troveManager.Troves(carol)
-    const dennis_Trove = await troveManager.Troves(dennis)
-    const erin_Trove = await troveManager.Troves(erin)
-    const freddy_Trove = await troveManager.Troves(freddy)
+    const alice_Trove = await troveManager.Troves(alice, assetAddress1)
+    const bob_Trove = await troveManager.Troves(bob, assetAddress1)
+    const carol_Trove = await troveManager.Troves(carol, assetAddress1)
+    const dennis_Trove = await troveManager.Troves(dennis, assetAddress1)
+    const erin_Trove = await troveManager.Troves(erin, assetAddress1)
+    const freddy_Trove = await troveManager.Troves(freddy, assetAddress1)
 
     // check that Alice's Trove remains active
-    assert.equal(alice_Trove[3], 1)
-    assert.isTrue(await sortedTroves.contains(alice))
+    assert.equal(alice_Trove[TroveData.status], 1)
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
 
     // check all other Troves are liquidated
-    assert.equal(bob_Trove[3], 3)
-    assert.equal(carol_Trove[3], 3)
-    assert.equal(dennis_Trove[3], 3)
-    assert.equal(erin_Trove[3], 3)
-    assert.equal(freddy_Trove[3], 3)
+    assert.equal(bob_Trove[TroveData.status], 3)
+    assert.equal(carol_Trove[TroveData.status], 3)
+    assert.equal(dennis_Trove[TroveData.status], 3)
+    assert.equal(erin_Trove[TroveData.status], 3)
+    assert.equal(freddy_Trove[TroveData.status], 3)
 
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
-    assert.isFalse(await sortedTroves.contains(dennis))
-    assert.isFalse(await sortedTroves.contains(erin))
-    assert.isFalse(await sortedTroves.contains(freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, erin))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
   })
 
   it("batchLiquidateTroves(): Liquidates all troves with ICR < 110%, transitioning Recovery -> Normal Mode", async () => {
@@ -3141,14 +3149,14 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // make 6 Troves accordingly
     // --- SETUP ---
 
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: carol } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(230, 16)), extraParams: { from: dennis } })
-    const { totalDebt: E_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
-    const { totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: carol } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(230, 16)), extraParams: { from: dennis } })
+    const { totalDebt: E_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
+    const { totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
 
     const spDeposit = B_totalDebt.add(C_totalDebt).add(D_totalDebt).add(E_totalDebt).add(F_totalDebt)
-    await openTrove({ ICR: toBN(dec(426, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(426, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
 
     // Alice deposits KUSD to Stability Pool
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: alice })
@@ -3159,12 +3167,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     // check Recovery Mode kicks in
 
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts)
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode_Before)
 
     // check TCR < 150%
     const _150percent = web3.utils.toBN('1500000000000000000')
-    const TCR_Before = await th.getTCR(contracts)
+    const TCR_Before = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_Before.lt(_150percent))
 
     /*
@@ -3178,12 +3186,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Elisa       102%
     Freddy      102%
     */
-    const alice_ICR = await troveManager.getCurrentICR(alice, price)
-    const bob_ICR = await troveManager.getCurrentICR(bob, price)
-    const carol_ICR = await troveManager.getCurrentICR(carol, price)
-    const dennis_ICR = await troveManager.getCurrentICR(dennis, price)
-    const erin_ICR = await troveManager.getCurrentICR(erin, price)
-    const freddy_ICR = await troveManager.getCurrentICR(freddy, price)
+    const alice_ICR = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const carol_ICR = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    const dennis_ICR = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    const erin_ICR = await troveManager.getCurrentICR(assetAddress1, erin, price)
+    const freddy_ICR = await troveManager.getCurrentICR(assetAddress1, freddy, price)
 
     // Alice should have ICR > 150%
     assert.isTrue(alice_ICR.gt(_150percent))
@@ -3200,40 +3208,40 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Only Alice should remain active - all others should be closed. */
 
     // call batchLiquidateTroves
-    await troveManager.batchLiquidateTroves([bob, carol, dennis, erin, freddy, alice]);
+    await troveManager.batchLiquidateTroves(assetAddress1, [bob, carol, dennis, erin, freddy, alice]);
 
     // check system is no longer in Recovery Mode
-    const recoveryMode_After = await th.checkRecoveryMode(contracts)
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isFalse(recoveryMode_After)
 
     // After liquidation, TCR should rise to above 150%. 
-    const TCR_After = await th.getTCR(contracts)
+    const TCR_After = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_After.gt(_150percent))
 
     // get all Troves
-    const alice_Trove = await troveManager.Troves(alice)
-    const bob_Trove = await troveManager.Troves(bob)
-    const carol_Trove = await troveManager.Troves(carol)
-    const dennis_Trove = await troveManager.Troves(dennis)
-    const erin_Trove = await troveManager.Troves(erin)
-    const freddy_Trove = await troveManager.Troves(freddy)
+    const alice_Trove = await troveManager.Troves(alice, assetAddress1)
+    const bob_Trove = await troveManager.Troves(bob, assetAddress1)
+    const carol_Trove = await troveManager.Troves(carol, assetAddress1)
+    const dennis_Trove = await troveManager.Troves(dennis, assetAddress1)
+    const erin_Trove = await troveManager.Troves(erin, assetAddress1)
+    const freddy_Trove = await troveManager.Troves(freddy, assetAddress1)
 
     // check that Alice's Trove remains active
-    assert.equal(alice_Trove[3], 1)
-    assert.isTrue(await sortedTroves.contains(alice))
+    assert.equal(alice_Trove[TroveData.status], 1)
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
 
     // check all other Troves are liquidated
-    assert.equal(bob_Trove[3], 3)
-    assert.equal(carol_Trove[3], 3)
-    assert.equal(dennis_Trove[3], 3)
-    assert.equal(erin_Trove[3], 3)
-    assert.equal(freddy_Trove[3], 3)
+    assert.equal(bob_Trove[TroveData.status], 3)
+    assert.equal(carol_Trove[TroveData.status], 3)
+    assert.equal(dennis_Trove[TroveData.status], 3)
+    assert.equal(erin_Trove[TroveData.status], 3)
+    assert.equal(freddy_Trove[TroveData.status], 3)
 
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
-    assert.isFalse(await sortedTroves.contains(dennis))
-    assert.isFalse(await sortedTroves.contains(erin))
-    assert.isFalse(await sortedTroves.contains(freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, erin))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
   })
 
   it("batchLiquidateTroves(): Liquidates all troves with ICR < 110%, transitioning Normal -> Recovery Mode", async () => {
@@ -3241,15 +3249,15 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // It also skips bob, as he is added twice, for being already liquidated
     // make 6 Troves accordingly
     // --- SETUP ---
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: carol } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(230, 16)), extraParams: { from: dennis } })
-    const { totalDebt: E_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
-    const { totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: carol } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(230, 16)), extraParams: { from: dennis } })
+    const { totalDebt: E_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: erin } })
+    const { totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(240, 16)), extraParams: { from: freddy } })
 
     const spDeposit = B_totalDebt.add(C_totalDebt).add(D_totalDebt).add(E_totalDebt).add(F_totalDebt)
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(426, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(426, 16)), extraKUSDAmount: A_totalDebt, extraParams: { from: whale } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(426, 16)), extraKUSDAmount: spDeposit, extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(426, 16)), extraKUSDAmount: A_totalDebt, extraParams: { from: whale } })
 
     // Alice deposits KUSD to Stability Pool
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: alice })
@@ -3257,7 +3265,7 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // to compensate borrowing fee
     await kusdToken.transfer(alice, A_totalDebt, { from: whale })
     // Alice closes trove
-    await borrowerOperations.closeTrove({ from: alice })
+    await borrowerOperations.closeTrove(assetAddress1, { from: alice })
 
     // price drops to 1ETH:85KUSD, reducing TCR below 150%
     await priceFeed.setPrice('85000000000000000000')
@@ -3265,12 +3273,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
     // check Recovery Mode kicks in
 
-    const recoveryMode_Before = await th.checkRecoveryMode(contracts)
+    const recoveryMode_Before = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isTrue(recoveryMode_Before)
 
     // check TCR < 150%
     const _150percent = web3.utils.toBN('1500000000000000000')
-    const TCR_Before = await th.getTCR(contracts)
+    const TCR_Before = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_Before.lt(_150percent))
 
     /*
@@ -3284,12 +3292,12 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Elisa       102%
     Freddy      102%
     */
-    alice_ICR = await troveManager.getCurrentICR(alice, price)
-    bob_ICR = await troveManager.getCurrentICR(bob, price)
-    carol_ICR = await troveManager.getCurrentICR(carol, price)
-    dennis_ICR = await troveManager.getCurrentICR(dennis, price)
-    erin_ICR = await troveManager.getCurrentICR(erin, price)
-    freddy_ICR = await troveManager.getCurrentICR(freddy, price)
+    alice_ICR = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    bob_ICR = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    carol_ICR = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    dennis_ICR = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    erin_ICR = await troveManager.getCurrentICR(assetAddress1, erin, price)
+    freddy_ICR = await troveManager.getCurrentICR(assetAddress1, freddy, price)
 
     // Alice should have ICR > 150%
     assert.isTrue(alice_ICR.gt(_150percent))
@@ -3306,121 +3314,121 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     Only Alice should remain active - all others should be closed. */
 
     // call batchLiquidateTroves
-    await troveManager.batchLiquidateTroves([alice, bob, bob, carol, dennis, erin, freddy]);
+    await troveManager.batchLiquidateTroves(assetAddress1, [alice, bob, bob, carol, dennis, erin, freddy]);
 
     // check system is no longer in Recovery Mode
-    const recoveryMode_After = await th.checkRecoveryMode(contracts)
+    const recoveryMode_After = await th.checkRecoveryMode(contracts, assetAddress1)
     assert.isFalse(recoveryMode_After)
 
     // After liquidation, TCR should rise to above 150%.
-    const TCR_After = await th.getTCR(contracts)
+    const TCR_After = await th.getTCR(contracts, assetAddress1)
     assert.isTrue(TCR_After.gt(_150percent))
 
     // get all Troves
-    const alice_Trove = await troveManager.Troves(alice)
-    const bob_Trove = await troveManager.Troves(bob)
-    const carol_Trove = await troveManager.Troves(carol)
-    const dennis_Trove = await troveManager.Troves(dennis)
-    const erin_Trove = await troveManager.Troves(erin)
-    const freddy_Trove = await troveManager.Troves(freddy)
+    const alice_Trove = await troveManager.Troves(alice, assetAddress1)
+    const bob_Trove = await troveManager.Troves(bob, assetAddress1)
+    const carol_Trove = await troveManager.Troves(carol, assetAddress1)
+    const dennis_Trove = await troveManager.Troves(dennis, assetAddress1)
+    const erin_Trove = await troveManager.Troves(erin, assetAddress1)
+    const freddy_Trove = await troveManager.Troves(freddy, assetAddress1)
 
     // check that Alice's Trove is closed
-    assert.equal(alice_Trove[3], 2)
+    assert.equal(alice_Trove[TroveData.status], 2)
 
     // check all other Troves are liquidated
-    assert.equal(bob_Trove[3], 3)
-    assert.equal(carol_Trove[3], 3)
-    assert.equal(dennis_Trove[3], 3)
-    assert.equal(erin_Trove[3], 3)
-    assert.equal(freddy_Trove[3], 3)
+    assert.equal(bob_Trove[TroveData.status], 3)
+    assert.equal(carol_Trove[TroveData.status], 3)
+    assert.equal(dennis_Trove[TroveData.status], 3)
+    assert.equal(erin_Trove[TroveData.status], 3)
+    assert.equal(freddy_Trove[TroveData.status], 3)
 
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
-    assert.isFalse(await sortedTroves.contains(dennis))
-    assert.isFalse(await sortedTroves.contains(erin))
-    assert.isFalse(await sortedTroves.contains(freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, erin))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
   })
 
   it("batchLiquidateTroves() with a non fullfilled liquidation: non liquidated trove remains active", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(211, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(212, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(211, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(212, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))
 
     const trovesToLiquidate = [alice, bob, carol]
-    await troveManager.batchLiquidateTroves(trovesToLiquidate)
+    await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
 
     // Check A and B closed
-    assert.isFalse(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
 
     // Check C remains active
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.equal((await troveManager.Troves(carol))[3].toString(), '1') // check Status is active
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status].toString(), '1') // check Status is active
   })
 
   it("batchLiquidateTroves() with a non fullfilled liquidation: non liquidated trove remains in Trove Owners array", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(211, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(212, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(211, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(212, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))
 
     const trovesToLiquidate = [alice, bob, carol]
-    await troveManager.batchLiquidateTroves(trovesToLiquidate)
+    await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
 
     // Check C is in Trove owners array
-    const arrayLength = (await troveManager.getTroveOwnersCount()).toNumber()
+    const arrayLength = (await troveManager.getTroveOwnersCount(assetAddress1)).toNumber()
     let addressFound = false;
     let addressIdx = 0;
 
     for (let i = 0; i < arrayLength; i++) {
-      const address = (await troveManager.TroveOwners(i)).toString()
+      const address = (await troveManager.TroveOwners(assetAddress1, i)).toString()
       if (address == carol) {
         addressFound = true
         addressIdx = i
@@ -3430,36 +3438,36 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.isTrue(addressFound);
 
     // Check TroveOwners idx on trove struct == idx of address found in TroveOwners array
-    const idxOnStruct = (await troveManager.Troves(carol))[4].toString()
+    const idxOnStruct = (await troveManager.Troves(carol, assetAddress1))[TroveData.arrayIndex].toString()
     assert.equal(addressIdx.toString(), idxOnStruct)
   })
 
   it("batchLiquidateTroves() with a non fullfilled liquidation: still can liquidate further troves after the non-liquidated, emptied pool", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: D_totalDebt, extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: D_totalDebt, extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C, D, E troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
-    const ICR_D = await troveManager.getCurrentICR(dennis, price)
-    const ICR_E = await troveManager.getCurrentICR(erin, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    const ICR_D = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    const ICR_E = await troveManager.getCurrentICR(assetAddress1, erin, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -3472,46 +3480,45 @@ contract('TroveManager - in Recovery Mode', async accounts => {
      but it will be enough to liquidate Dennis. Afterwards the pool will be empty,
      so Erin won’t liquidated. */
     const trovesToLiquidate = [alice, bob, carol, dennis, erin]
-    const tx = await troveManager.batchLiquidateTroves(trovesToLiquidate)
-    console.log('gasUsed: ', tx.receipt.gasUsed)
+    const tx = await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
 
     // Check A, B and D are closed
-    assert.isFalse(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
 
     // Check whale, C, D and E stay active
-    assert.isTrue(await sortedTroves.contains(whale))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(erin))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, erin))
   })
 
   it("batchLiquidateTroves() with a non fullfilled liquidation: still can liquidate further troves after the non-liquidated, non emptied pool", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraKUSDAmount: D_totalDebt, extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraKUSDAmount: D_totalDebt, extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C, D, E troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
-    const ICR_D = await troveManager.getCurrentICR(dennis, price)
-    const ICR_E = await troveManager.getCurrentICR(erin, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    const ICR_D = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    const ICR_E = await troveManager.getCurrentICR(assetAddress1, erin, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -3526,58 +3533,57 @@ contract('TroveManager - in Recovery Mode', async accounts => {
      Note that, compared to the previous test, this one will make 1 more loop iteration,
      so it will consume more gas. */
     const trovesToLiquidate = [alice, bob, carol, dennis, erin]
-    const tx = await troveManager.batchLiquidateTroves(trovesToLiquidate)
-    console.log('gasUsed: ', tx.receipt.gasUsed)
+    const tx = await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
 
     // Check A, B and D are closed
-    assert.isFalse(await sortedTroves.contains(alice))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, alice))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
 
     // Check whale, C, D and E stay active
-    assert.isTrue(await sortedTroves.contains(whale))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(erin))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, erin))
   })
 
   it("batchLiquidateTroves() with a non fullfilled liquidation: total liquidated coll and debt is correct", async () => {
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
-    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
-    const { collateral: D_coll, totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    const { collateral: E_coll, totalDebt: E_totalDebt } = await openTrove({ ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: bob } })
+    const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: carol } })
+    const { collateral: D_coll, totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    const { collateral: E_coll, totalDebt: E_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(208, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C, D, E troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))
 
-    const entireSystemCollBefore = await troveManager.getEntireSystemColl()
-    const entireSystemDebtBefore = await troveManager.getEntireSystemDebt()
+    const entireSystemCollBefore = await troveManager.getEntireSystemColl(assetAddress1)
+    const entireSystemDebtBefore = await troveManager.getEntireSystemDebt(assetAddress1)
 
     const trovesToLiquidate = [alice, bob, carol]
-    await troveManager.batchLiquidateTroves(trovesToLiquidate)
+    await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
 
     // Expect system debt reduced by 203 KUSD and system coll by 2 ETH
-    const entireSystemCollAfter = await troveManager.getEntireSystemColl()
-    const entireSystemDebtAfter = await troveManager.getEntireSystemDebt()
+    const entireSystemCollAfter = await troveManager.getEntireSystemColl(assetAddress1)
+    const entireSystemDebtAfter = await troveManager.getEntireSystemDebt(assetAddress1)
 
     const changeInEntireSystemColl = entireSystemCollBefore.sub(entireSystemCollAfter)
     const changeInEntireSystemDebt = entireSystemDebtBefore.sub(entireSystemDebtAfter)
@@ -3587,36 +3593,36 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   })
 
   it("batchLiquidateTroves() with a non fullfilled liquidation: emits correct liquidation event values", async () => {
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraParams: { from: alice } })
-    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(211, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(212, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraParams: { from: alice } })
+    const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(211, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(212, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))
 
     const trovesToLiquidate = [alice, bob, carol]
-    const liquidationTx = await troveManager.batchLiquidateTroves(trovesToLiquidate)
+    const liquidationTx = await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
 
     const [liquidatedDebt, liquidatedColl, collGasComp, kusdGasComp] = th.getEmittedLiquidationValues(liquidationTx)
 
@@ -3629,68 +3635,68 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // check collateral surplus
     const alice_remainingCollateral = A_coll.sub(A_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
     const bob_remainingCollateral = B_coll.sub(B_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(alice), alice_remainingCollateral)
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(bob), bob_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, alice), alice_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, bob), bob_remainingCollateral)
 
     // can claim collateral
-    const alice_balanceBefore = th.toBN(await web3.eth.getBalance(alice))
-    const ALICE_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: alice, gasPrice: GAS_PRICE  }))
-    const alice_balanceAfter = th.toBN(await web3.eth.getBalance(alice))
-    //th.assertIsApproximatelyEqual(alice_balanceAfter, alice_balanceBefore.add(th.toBN(alice_remainingCollateral).sub(th.toBN(ALICE_GAS * GAS_PRICE))))
+    const alice_balanceBefore = th.toBN(await erc20Asset1.balanceOf(alice))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: alice, gasPrice: GAS_PRICE })
+    const alice_balanceAfter = th.toBN(await erc20Asset1.balanceOf(alice))
+    th.assertIsApproximatelyEqual(alice_balanceAfter, alice_balanceBefore.add(th.toBN(alice_remainingCollateral)))
 
-    const bob_balanceBefore = th.toBN(await web3.eth.getBalance(bob))
-    const BOB_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: bob, gasPrice: GAS_PRICE  }))
-    const bob_balanceAfter = th.toBN(await web3.eth.getBalance(bob))
-    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral).sub(th.toBN(BOB_GAS * GAS_PRICE))))
+    const bob_balanceBefore = th.toBN(await erc20Asset1.balanceOf(bob))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: bob, gasPrice: GAS_PRICE })
+    const bob_balanceAfter = th.toBN(await erc20Asset1.balanceOf(bob))
+    th.assertIsApproximatelyEqual(bob_balanceAfter, bob_balanceBefore.add(th.toBN(bob_remainingCollateral)))
   })
 
   it("batchLiquidateTroves() with a non fullfilled liquidation: ICR of non liquidated trove does not change", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(211, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(212, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(210, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(211, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(212, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(210, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(219, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(221, 16)), extraParams: { from: erin } })
 
     // Whale provides KUSD to the SP
     const spDeposit = A_totalDebt.add(B_totalDebt).add(C_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(220, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops 
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check A, B, C troves are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C_Before = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C_Before = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
     assert.isTrue(ICR_C_Before.gt(mv._MCR) && ICR_C_Before.lt(TCR))
 
     const trovesToLiquidate = [alice, bob, carol]
-    await troveManager.batchLiquidateTroves(trovesToLiquidate)
+    await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
 
-    const ICR_C_After = await troveManager.getCurrentICR(carol, price)
+    const ICR_C_After = await troveManager.getCurrentICR(assetAddress1, carol, price)
     assert.equal(ICR_C_Before.toString(), ICR_C_After)
   })
 
   it("batchLiquidateTroves(), with 110% < ICR < TCR, and StabilityPool KUSD > debt to liquidate: can liquidate troves out of order", async () => {
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(202, 16)), extraParams: { from: bob } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(204, 16)), extraParams: { from: carol } })
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
-    await openTrove({ ICR: toBN(dec(280, 16)), extraKUSDAmount: dec(500, 18), extraParams: { from: erin } })
-    await openTrove({ ICR: toBN(dec(282, 16)), extraKUSDAmount: dec(500, 18), extraParams: { from: freddy } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(200, 16)), extraParams: { from: alice } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(202, 16)), extraParams: { from: bob } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(204, 16)), extraParams: { from: carol } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(206, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(280, 16)), extraKUSDAmount: dec(500, 18), extraParams: { from: erin } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(282, 16)), extraKUSDAmount: dec(500, 18), extraParams: { from: freddy } })
 
     // Whale provides 1000 KUSD to the SP
     const spDeposit = A_totalDebt.add(C_totalDebt).add(D_totalDebt)
-    await openTrove({ ICR: toBN(dec(219, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(219, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops
@@ -3698,14 +3704,14 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const price = await priceFeed.getPrice()
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check troves A-D are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
-    const ICR_D = await troveManager.getCurrentICR(dennis, price)
-    const TCR = await th.getTCR(contracts)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
+    const ICR_D = await troveManager.getCurrentICR(assetAddress1, dennis, price)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -3717,47 +3723,47 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // Liquidate out of ICR order: D, B, C. A (lowest ICR) not included.
     const trovesToLiquidate = [dennis, bob, carol]
 
-    const liquidationTx = await troveManager.batchLiquidateTroves(trovesToLiquidate)
+    const liquidationTx = await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
 
     // Check transaction succeeded
     assert.isTrue(liquidationTx.receipt.status)
 
     // Confirm troves D, B, C removed
-    assert.isFalse(await sortedTroves.contains(dennis))
-    assert.isFalse(await sortedTroves.contains(bob))
-    assert.isFalse(await sortedTroves.contains(carol))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, bob))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, carol))
 
     // Confirm troves have status 'liquidated' (Status enum element idx 3)
-    assert.equal((await troveManager.Troves(dennis))[3], '3')
-    assert.equal((await troveManager.Troves(dennis))[3], '3')
-    assert.equal((await troveManager.Troves(dennis))[3], '3')
+    assert.equal((await troveManager.Troves(dennis, assetAddress1))[TroveData.status], '3')
+    assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status], '3')
+    assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status], '3')
   })
 
   it("batchLiquidateTroves(), with 110% < ICR < TCR, and StabilityPool empty: doesn't liquidate any troves", async () => {
-    await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: alice } })
-    const { totalDebt: bobDebt_Before } = await openTrove({ ICR: toBN(dec(224, 16)), extraParams: { from: bob } })
-    const { totalDebt: carolDebt_Before } = await openTrove({ ICR: toBN(dec(226, 16)), extraParams: { from: carol } })
-    const { totalDebt: dennisDebt_Before } = await openTrove({ ICR: toBN(dec(228, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: alice } })
+    const { totalDebt: bobDebt_Before } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(224, 16)), extraParams: { from: bob } })
+    const { totalDebt: carolDebt_Before } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(226, 16)), extraParams: { from: carol } })
+    const { totalDebt: dennisDebt_Before } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(228, 16)), extraParams: { from: dennis } })
 
-    const bobColl_Before = (await troveManager.Troves(bob))[1]
-    const carolColl_Before = (await troveManager.Troves(carol))[1]
-    const dennisColl_Before = (await troveManager.Troves(dennis))[1]
+    const bobColl_Before = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll]
+    const carolColl_Before = (await troveManager.Troves(carol, assetAddress1))[TroveData.coll]
+    const dennisColl_Before = (await troveManager.Troves(dennis, assetAddress1))[TroveData.coll]
 
-    await openTrove({ ICR: toBN(dec(228, 16)), extraParams: { from: erin } })
-    await openTrove({ ICR: toBN(dec(230, 16)), extraParams: { from: freddy } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(228, 16)), extraParams: { from: erin } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(230, 16)), extraParams: { from: freddy } })
 
     // Price drops
     await priceFeed.setPrice(dec(120, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Check Recovery Mode is active
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Check troves A-D are in range 110% < ICR < TCR
-    const ICR_A = await troveManager.getCurrentICR(alice, price)
-    const ICR_B = await troveManager.getCurrentICR(bob, price)
-    const ICR_C = await troveManager.getCurrentICR(carol, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
     assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
     assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -3766,26 +3772,26 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // Troves are ordered by ICR, low to high: A, B, C, D. 
     // Liquidate out of ICR order: D, B, C. A (lowest ICR) not included.
     const trovesToLiquidate = [dennis, bob, carol]
-    await assertRevert(troveManager.batchLiquidateTroves(trovesToLiquidate), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate), "TroveManager: nothing to liquidate")
 
     // Confirm troves D, B, C remain in system
-    assert.isTrue(await sortedTroves.contains(dennis))
-    assert.isTrue(await sortedTroves.contains(bob))
-    assert.isTrue(await sortedTroves.contains(carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, bob))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
 
     // Confirm troves have status 'active' (Status enum element idx 1)
-    assert.equal((await troveManager.Troves(dennis))[3], '1')
-    assert.equal((await troveManager.Troves(dennis))[3], '1')
-    assert.equal((await troveManager.Troves(dennis))[3], '1')
+    assert.equal((await troveManager.Troves(dennis, assetAddress1))[TroveData.status], '1')
+    assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status], '1')
+    assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status], '1')
 
     // Confirm D, B, C coll & debt have not changed
-    const dennisDebt_After = (await troveManager.Troves(dennis))[0].add(await troveManager.getPendingKUSDDebtReward(dennis))
-    const bobDebt_After = (await troveManager.Troves(bob))[0].add(await troveManager.getPendingKUSDDebtReward(bob))
-    const carolDebt_After = (await troveManager.Troves(carol))[0].add(await troveManager.getPendingKUSDDebtReward(carol))
+    const dennisDebt_After = (await troveManager.Troves(dennis, assetAddress1))[TroveData.debt].add(await troveManager.getPendingKUSDDebtReward(assetAddress1, dennis))
+    const bobDebt_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.debt].add(await troveManager.getPendingKUSDDebtReward(assetAddress1, bob))
+    const carolDebt_After = (await troveManager.Troves(carol, assetAddress1))[TroveData.debt].add(await troveManager.getPendingKUSDDebtReward(assetAddress1, carol))
 
-    const dennisColl_After = (await troveManager.Troves(dennis))[1].add(await troveManager.getPendingETHReward(dennis))  
-    const bobColl_After = (await troveManager.Troves(bob))[1].add(await troveManager.getPendingETHReward(bob))
-    const carolColl_After = (await troveManager.Troves(carol))[1].add(await troveManager.getPendingETHReward(carol))
+    const dennisColl_After = (await troveManager.Troves(dennis, assetAddress1))[TroveData.coll].add(await troveManager.getPendingReward(assetAddress1, dennis))
+    const bobColl_After = (await troveManager.Troves(bob, assetAddress1))[TroveData.coll].add(await troveManager.getPendingReward(assetAddress1, bob))
+    const carolColl_After = (await troveManager.Troves(carol, assetAddress1))[TroveData.coll].add(await troveManager.getPendingReward(assetAddress1, carol))
 
     assert.isTrue(dennisColl_After.eq(dennisColl_Before))
     assert.isTrue(bobColl_After.eq(bobColl_Before))
@@ -3798,49 +3804,49 @@ contract('TroveManager - in Recovery Mode', async accounts => {
 
   it('batchLiquidateTroves(): skips liquidation of troves with ICR > TCR, regardless of Stability Pool size', async () => {
     // Troves that will fall into ICR range 100-MCR
-    const { totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(194, 16)), extraParams: { from: A } })
-    const { totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(196, 16)), extraParams: { from: B } })
-    const { totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(198, 16)), extraParams: { from: C } })
+    const { totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(194, 16)), extraParams: { from: A } })
+    const { totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(196, 16)), extraParams: { from: B } })
+    const { totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(198, 16)), extraParams: { from: C } })
 
     // Troves that will fall into ICR range 110-TCR
-    const { totalDebt: D_totalDebt } = await openTrove({ ICR: toBN(dec(221, 16)), extraParams: { from: D } })
-    await openTrove({ ICR: toBN(dec(223, 16)), extraParams: { from: E } })
-    await openTrove({ ICR: toBN(dec(225, 16)), extraParams: { from: F } })
+    const { totalDebt: D_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(221, 16)), extraParams: { from: D } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(223, 16)), extraParams: { from: E } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(225, 16)), extraParams: { from: F } })
 
     // Troves that will fall into ICR range >= TCR
-    const { totalDebt: G_totalDebt } = await openTrove({ ICR: toBN(dec(250, 16)), extraParams: { from: G } })
-    const { totalDebt: H_totalDebt } = await openTrove({ ICR: toBN(dec(270, 16)), extraParams: { from: H } })
-    const { totalDebt: I_totalDebt } = await openTrove({ ICR: toBN(dec(290, 16)), extraParams: { from: I } })
+    const { totalDebt: G_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraParams: { from: G } })
+    const { totalDebt: H_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(270, 16)), extraParams: { from: H } })
+    const { totalDebt: I_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(290, 16)), extraParams: { from: I } })
 
     // Whale adds KUSD to SP
     const spDeposit = A_totalDebt.add(C_totalDebt).add(D_totalDebt).add(G_totalDebt).add(H_totalDebt).add(I_totalDebt)
-    await openTrove({ ICR: toBN(dec(245, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(245, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops, but all troves remain active
-    await priceFeed.setPrice(dec(110, 18)) 
+    await priceFeed.setPrice(dec(110, 18))
     const price = await priceFeed.getPrice()
-    const TCR = await th.getTCR(contracts)
+    const TCR = await th.getTCR(contracts, assetAddress1)
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
-    const G_collBefore = (await troveManager.Troves(G))[1]
-    const G_debtBefore = (await troveManager.Troves(G))[0]
-    const H_collBefore = (await troveManager.Troves(H))[1]
-    const H_debtBefore = (await troveManager.Troves(H))[0]
-    const I_collBefore = (await troveManager.Troves(I))[1]
-    const I_debtBefore = (await troveManager.Troves(I))[0]
+    const G_collBefore = (await troveManager.Troves(G, assetAddress1))[TroveData.coll]
+    const G_debtBefore = (await troveManager.Troves(G, assetAddress1))[TroveData.debt]
+    const H_collBefore = (await troveManager.Troves(H, assetAddress1))[TroveData.coll]
+    const H_debtBefore = (await troveManager.Troves(H, assetAddress1))[TroveData.debt]
+    const I_collBefore = (await troveManager.Troves(I, assetAddress1))[TroveData.coll]
+    const I_debtBefore = (await troveManager.Troves(I, assetAddress1))[TroveData.debt]
 
-    const ICR_A = await troveManager.getCurrentICR(A, price) 
-    const ICR_B = await troveManager.getCurrentICR(B, price) 
-    const ICR_C = await troveManager.getCurrentICR(C, price) 
-    const ICR_D = await troveManager.getCurrentICR(D, price)
-    const ICR_E = await troveManager.getCurrentICR(E, price)
-    const ICR_F = await troveManager.getCurrentICR(F, price)
-    const ICR_G = await troveManager.getCurrentICR(G, price)
-    const ICR_H = await troveManager.getCurrentICR(H, price)
-    const ICR_I = await troveManager.getCurrentICR(I, price)
+    const ICR_A = await troveManager.getCurrentICR(assetAddress1, A, price)
+    const ICR_B = await troveManager.getCurrentICR(assetAddress1, B, price)
+    const ICR_C = await troveManager.getCurrentICR(assetAddress1, C, price)
+    const ICR_D = await troveManager.getCurrentICR(assetAddress1, D, price)
+    const ICR_E = await troveManager.getCurrentICR(assetAddress1, E, price)
+    const ICR_F = await troveManager.getCurrentICR(assetAddress1, F, price)
+    const ICR_G = await troveManager.getCurrentICR(assetAddress1, G, price)
+    const ICR_H = await troveManager.getCurrentICR(assetAddress1, H, price)
+    const ICR_I = await troveManager.getCurrentICR(assetAddress1, I, price)
 
     // Check A-C are in range 100-110
     assert.isTrue(ICR_A.gte(mv._ICR100) && ICR_A.lt(mv._MCR))
@@ -3858,107 +3864,107 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_I.gte(TCR))
 
     // Attempt to liquidate only troves with ICR > TCR% 
-    await assertRevert(troveManager.batchLiquidateTroves([G, H, I]), "TroveManager: nothing to liquidate")
+    await assertRevert(troveManager.batchLiquidateTroves(assetAddress1, [G, H, I]), "TroveManager: nothing to liquidate")
 
     // Check G, H, I remain in system
-    assert.isTrue(await sortedTroves.contains(G))
-    assert.isTrue(await sortedTroves.contains(H))
-    assert.isTrue(await sortedTroves.contains(I))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, G))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, H))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, I))
 
     // Check G, H, I coll and debt have not changed
-    assert.equal(G_collBefore.eq(await troveManager.Troves(G))[1])
-    assert.equal(G_debtBefore.eq(await troveManager.Troves(G))[0])
-    assert.equal(H_collBefore.eq(await troveManager.Troves(H))[1])
-    assert.equal(H_debtBefore.eq(await troveManager.Troves(H))[0])
-    assert.equal(I_collBefore.eq(await troveManager.Troves(I))[1])
-    assert.equal(I_debtBefore.eq(await troveManager.Troves(I))[0])
+    assert.equal(G_collBefore.eq(await troveManager.Troves(G, assetAddress1))[TroveData.coll])
+    assert.equal(G_debtBefore.eq(await troveManager.Troves(G, assetAddress1))[TroveData.debt])
+    assert.equal(H_collBefore.eq(await troveManager.Troves(H, assetAddress1))[TroveData.coll])
+    assert.equal(H_debtBefore.eq(await troveManager.Troves(H, assetAddress1))[TroveData.debt])
+    assert.equal(I_collBefore.eq(await troveManager.Troves(I, assetAddress1))[TroveData.coll])
+    assert.equal(I_debtBefore.eq(await troveManager.Troves(I, assetAddress1))[TroveData.debt])
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
-  
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
+
     // Attempt to liquidate a variety of troves with SP covering whole batch.
     // Expect A, C, D to be liquidated, and G, H, I to remain in system
-    await troveManager.batchLiquidateTroves([C, D, G, H, A, I])
-    
+    await troveManager.batchLiquidateTroves(assetAddress1, [C, D, G, H, A, I])
+
     // Confirm A, C, D liquidated  
-    assert.isFalse(await sortedTroves.contains(C))
-    assert.isFalse(await sortedTroves.contains(A))
-    assert.isFalse(await sortedTroves.contains(D))
-    
+    assert.isFalse(await sortedTroves.contains(assetAddress1, C))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, A))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, D))
+
     // Check G, H, I remain in system
-    assert.isTrue(await sortedTroves.contains(G))
-    assert.isTrue(await sortedTroves.contains(H))
-    assert.isTrue(await sortedTroves.contains(I))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, G))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, H))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, I))
 
     // Check coll and debt have not changed
-    assert.equal(G_collBefore.eq(await troveManager.Troves(G))[1])
-    assert.equal(G_debtBefore.eq(await troveManager.Troves(G))[0])
-    assert.equal(H_collBefore.eq(await troveManager.Troves(H))[1])
-    assert.equal(H_debtBefore.eq(await troveManager.Troves(H))[0])
-    assert.equal(I_collBefore.eq(await troveManager.Troves(I))[1])
-    assert.equal(I_debtBefore.eq(await troveManager.Troves(I))[0])
+    assert.equal(G_collBefore.eq(await troveManager.Troves(G, assetAddress1))[TroveData.coll])
+    assert.equal(G_debtBefore.eq(await troveManager.Troves(G, assetAddress1))[TroveData.debt])
+    assert.equal(H_collBefore.eq(await troveManager.Troves(H, assetAddress1))[TroveData.coll])
+    assert.equal(H_debtBefore.eq(await troveManager.Troves(H, assetAddress1))[TroveData.debt])
+    assert.equal(I_collBefore.eq(await troveManager.Troves(I, assetAddress1))[TroveData.coll])
+    assert.equal(I_debtBefore.eq(await troveManager.Troves(I, assetAddress1))[TroveData.debt])
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Whale withdraws entire deposit, and re-deposits 132 KUSD
     // Increasing the price for a moment to avoid pending liquidations to block withdrawal
     await priceFeed.setPrice(dec(200, 18))
-    await stabilityPool.withdrawFromSP(spDeposit, {from: whale})
+    await stabilityPool.withdrawFromSP(spDeposit, { from: whale })
     await priceFeed.setPrice(dec(110, 18))
-    await stabilityPool.provideToSP(B_totalDebt.add(toBN(dec(50, 18))), ZERO_ADDRESS, {from: whale})
+    await stabilityPool.provideToSP(B_totalDebt.add(toBN(dec(50, 18))), ZERO_ADDRESS, { from: whale })
 
     // B and E are still in range 110-TCR.
     // Attempt to liquidate B, G, H, I, E.
     // Expected Stability Pool to fully absorb B (92 KUSD + 10 virtual debt), 
     // but not E as there are not enough funds in Stability Pool
-    
-    const stabilityBefore = await stabilityPool.getTotalKUSDDeposits()
-    const dEbtBefore = (await troveManager.Troves(E))[0]
 
-    await troveManager.batchLiquidateTroves([B, G, H, I, E])
-    
-    const dEbtAfter = (await troveManager.Troves(E))[0]
+    const stabilityBefore = await stabilityPool.getTotalKUSDDeposits()
+    const dEbtBefore = (await troveManager.Troves(E, assetAddress1))[TroveData.debt]
+
+    await troveManager.batchLiquidateTroves(assetAddress1, [B, G, H, I, E])
+
+    const dEbtAfter = (await troveManager.Troves(E, assetAddress1))[TroveData.debt]
     const stabilityAfter = await stabilityPool.getTotalKUSDDeposits()
-    
-    const stabilityDelta = stabilityBefore.sub(stabilityAfter)  
+
+    const stabilityDelta = stabilityBefore.sub(stabilityAfter)
     const dEbtDelta = dEbtBefore.sub(dEbtAfter)
 
     th.assertIsApproximatelyEqual(stabilityDelta, B_totalDebt)
     assert.equal((dEbtDelta.toString()), '0')
-    
+
     // Confirm B removed and E active 
-    assert.isFalse(await sortedTroves.contains(B)) 
-    assert.isTrue(await sortedTroves.contains(E))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, B))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, E))
 
     // Check G, H, I remain in system
-    assert.isTrue(await sortedTroves.contains(G))
-    assert.isTrue(await sortedTroves.contains(H))
-    assert.isTrue(await sortedTroves.contains(I))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, G))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, H))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, I))
 
     // Check coll and debt have not changed
-    assert.equal(G_collBefore.eq(await troveManager.Troves(G))[1])
-    assert.equal(G_debtBefore.eq(await troveManager.Troves(G))[0])
-    assert.equal(H_collBefore.eq(await troveManager.Troves(H))[1])
-    assert.equal(H_debtBefore.eq(await troveManager.Troves(H))[0])
-    assert.equal(I_collBefore.eq(await troveManager.Troves(I))[1])
-    assert.equal(I_debtBefore.eq(await troveManager.Troves(I))[0])
+    assert.equal(G_collBefore.eq(await troveManager.Troves(G, assetAddress1))[TroveData.coll])
+    assert.equal(G_debtBefore.eq(await troveManager.Troves(G, assetAddress1))[TroveData.debt])
+    assert.equal(H_collBefore.eq(await troveManager.Troves(H, assetAddress1))[TroveData.coll])
+    assert.equal(H_debtBefore.eq(await troveManager.Troves(H, assetAddress1))[TroveData.debt])
+    assert.equal(I_collBefore.eq(await troveManager.Troves(I, assetAddress1))[TroveData.coll])
+    assert.equal(I_debtBefore.eq(await troveManager.Troves(I, assetAddress1))[TroveData.debt])
   })
 
   it('batchLiquidateTroves(): emits liquidation event with correct values when all troves have ICR > 110% and Stability Pool covers a subset of troves', async () => {
     // Troves to be absorbed by SP
-    const { collateral: F_coll, totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: freddy } })
-    const { collateral: G_coll, totalDebt: G_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: greta } })
+    const { collateral: F_coll, totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: freddy } })
+    const { collateral: G_coll, totalDebt: G_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: greta } })
 
     // Troves to be spared
-    await openTrove({ ICR: toBN(dec(250, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(266, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(308, 16)), extraParams: { from: dennis } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(308, 16)), extraParams: { from: dennis } })
 
     // Whale adds KUSD to SP
     const spDeposit = F_totalDebt.add(G_totalDebt)
-    await openTrove({ ICR: toBN(dec(285, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops, but all troves remain active
@@ -3966,14 +3972,14 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Confirm all troves have ICR > MCR
-    assert.isTrue((await troveManager.getCurrentICR(freddy, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(greta, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(alice, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(bob, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(carol, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, freddy, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, greta, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, alice, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, bob, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, carol, price)).gte(mv._MCR))
 
     // Confirm KUSD in Stability Pool
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), spDeposit.toString())
@@ -3981,19 +3987,19 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const trovesToLiquidate = [freddy, greta, alice, bob, carol, dennis, whale]
 
     // Attempt liqudation sequence
-    const liquidationTx = await troveManager.batchLiquidateTroves(trovesToLiquidate)
+    const liquidationTx = await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
     const [liquidatedDebt, liquidatedColl, gasComp] = th.getEmittedLiquidationValues(liquidationTx)
 
     // Check F and G were liquidated
-    assert.isFalse(await sortedTroves.contains(freddy))
-    assert.isFalse(await sortedTroves.contains(greta))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, greta))
 
     // Check whale and A-D remain active
-    assert.isTrue(await sortedTroves.contains(alice))
-    assert.isTrue(await sortedTroves.contains(bob))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(dennis))
-    assert.isTrue(await sortedTroves.contains(whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, bob))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
 
     // Liquidation event emits coll = (F_debt + G_debt)/price*1.1*0.995, and debt = (F_debt + G_debt)
     th.assertIsApproximatelyEqual(liquidatedDebt, F_totalDebt.add(G_totalDebt))
@@ -4002,37 +4008,35 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // check collateral surplus
     const freddy_remainingCollateral = F_coll.sub(F_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
     const greta_remainingCollateral = G_coll.sub(G_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(freddy), freddy_remainingCollateral)
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(greta), greta_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, freddy), freddy_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, greta), greta_remainingCollateral)
 
     // can claim collateral
-    const freddy_balanceBefore = th.toBN(await web3.eth.getBalance(freddy))
-    const FREDDY_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: freddy, gasPrice: GAS_PRICE  }))
-    const freddy_expectedBalance = freddy_balanceBefore.sub(th.toBN(FREDDY_GAS * GAS_PRICE))
-    const freddy_balanceAfter = th.toBN(await web3.eth.getBalance(freddy))
-    th.assertIsApproximatelyEqual(freddy_balanceAfter, freddy_expectedBalance.add(th.toBN(freddy_remainingCollateral)))
+    const freddy_balanceBefore = th.toBN(await erc20Asset1.balanceOf(freddy))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: freddy, gasPrice: GAS_PRICE })
+    const freddy_balanceAfter = th.toBN(await erc20Asset1.balanceOf(freddy))
+    th.assertIsApproximatelyEqual(freddy_balanceAfter, freddy_balanceBefore.add(th.toBN(freddy_remainingCollateral)))
 
-    const greta_balanceBefore = th.toBN(await web3.eth.getBalance(greta))
-    const GRETA_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: greta, gasPrice: GAS_PRICE  }))
-    const greta_expectedBalance = greta_balanceBefore.sub(th.toBN(GRETA_GAS * GAS_PRICE))
-    const greta_balanceAfter = th.toBN(await web3.eth.getBalance(greta))
-    th.assertIsApproximatelyEqual(greta_balanceAfter, greta_expectedBalance.add(th.toBN(greta_remainingCollateral)))
+    const greta_balanceBefore = th.toBN(await erc20Asset1.balanceOf(greta))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: greta, gasPrice: GAS_PRICE })
+    const greta_balanceAfter = th.toBN(await erc20Asset1.balanceOf(greta))
+    th.assertIsApproximatelyEqual(greta_balanceAfter, greta_balanceBefore.add(th.toBN(greta_remainingCollateral)))
   })
 
   it('batchLiquidateTroves(): emits liquidation event with correct values when all troves have ICR > 110% and Stability Pool covers a subset of troves, including a partial', async () => {
     // Troves to be absorbed by SP
-    const { collateral: F_coll, totalDebt: F_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: freddy } })
-    const { collateral: G_coll, totalDebt: G_totalDebt } = await openTrove({ ICR: toBN(dec(222, 16)), extraParams: { from: greta } })
+    const { collateral: F_coll, totalDebt: F_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: freddy } })
+    const { collateral: G_coll, totalDebt: G_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(222, 16)), extraParams: { from: greta } })
 
     // Troves to be spared
-    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(250, 16)), extraParams: { from: alice } })
-    await openTrove({ ICR: toBN(dec(266, 16)), extraParams: { from: bob } })
-    await openTrove({ ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
-    await openTrove({ ICR: toBN(dec(308, 16)), extraParams: { from: dennis } })
+    const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1, ICR: toBN(dec(250, 16)), extraParams: { from: alice } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(266, 16)), extraParams: { from: bob } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraParams: { from: carol } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(308, 16)), extraParams: { from: dennis } })
 
     // Whale opens trove and adds 220 KUSD to SP
     const spDeposit = F_totalDebt.add(G_totalDebt).add(A_totalDebt.div(toBN(2)))
-    await openTrove({ ICR: toBN(dec(285, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
+    await openTrove({ asset: assetAddress1, ICR: toBN(dec(285, 16)), extraKUSDAmount: spDeposit, extraParams: { from: whale } })
     await stabilityPool.provideToSP(spDeposit, ZERO_ADDRESS, { from: whale })
 
     // Price drops, but all troves remain active
@@ -4040,14 +4044,14 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const price = await priceFeed.getPrice()
 
     // Confirm Recovery Mode
-    assert.isTrue(await th.checkRecoveryMode(contracts))
+    assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
     // Confirm all troves have ICR > MCR
-    assert.isTrue((await troveManager.getCurrentICR(freddy, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(greta, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(alice, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(bob, price)).gte(mv._MCR))
-    assert.isTrue((await troveManager.getCurrentICR(carol, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, freddy, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, greta, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, alice, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, bob, price)).gte(mv._MCR))
+    assert.isTrue((await troveManager.getCurrentICR(assetAddress1, carol, price)).gte(mv._MCR))
 
     // Confirm KUSD in Stability Pool
     assert.equal((await stabilityPool.getTotalKUSDDeposits()).toString(), spDeposit.toString())
@@ -4055,23 +4059,23 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     const trovesToLiquidate = [freddy, greta, alice, bob, carol, dennis, whale]
 
     // Attempt liqudation sequence
-    const liquidationTx = await troveManager.batchLiquidateTroves(trovesToLiquidate)
+    const liquidationTx = await troveManager.batchLiquidateTroves(assetAddress1, trovesToLiquidate)
     const [liquidatedDebt, liquidatedColl, gasComp] = th.getEmittedLiquidationValues(liquidationTx)
 
     // Check F and G were liquidated
-    assert.isFalse(await sortedTroves.contains(freddy))
-    assert.isFalse(await sortedTroves.contains(greta))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, freddy))
+    assert.isFalse(await sortedTroves.contains(assetAddress1, greta))
 
     // Check whale and A-D remain active
-    assert.isTrue(await sortedTroves.contains(alice))
-    assert.isTrue(await sortedTroves.contains(bob))
-    assert.isTrue(await sortedTroves.contains(carol))
-    assert.isTrue(await sortedTroves.contains(dennis))
-    assert.isTrue(await sortedTroves.contains(whale))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, alice))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, bob))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, carol))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, dennis))
+    assert.isTrue(await sortedTroves.contains(assetAddress1, whale))
 
     // Check A's collateral and debt are the same
-    const entireColl_A = (await troveManager.Troves(alice))[1].add(await troveManager.getPendingETHReward(alice))
-    const entireDebt_A = (await troveManager.Troves(alice))[0].add(await troveManager.getPendingKUSDDebtReward(alice))
+    const entireColl_A = (await troveManager.Troves(alice, assetAddress1))[TroveData.coll].add(await troveManager.getPendingReward(assetAddress1, alice))
+    const entireDebt_A = (await troveManager.Troves(alice, assetAddress1))[TroveData.debt].add(await troveManager.getPendingKUSDDebtReward(assetAddress1, alice))
 
     assert.equal(entireColl_A.toString(), A_coll)
     th.assertIsApproximatelyEqual(entireDebt_A.toString(), A_totalDebt)
@@ -4085,21 +4089,19 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     // check collateral surplus
     const freddy_remainingCollateral = F_coll.sub(F_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
     const greta_remainingCollateral = G_coll.sub(G_totalDebt.mul(th.toBN(dec(11, 17))).div(price))
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(freddy), freddy_remainingCollateral)
-    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(greta), greta_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, freddy), freddy_remainingCollateral)
+    th.assertIsApproximatelyEqual(await collSurplusPool.getCollateral(assetAddress1, greta), greta_remainingCollateral)
 
     // can claim collateral
-    const freddy_balanceBefore = th.toBN(await web3.eth.getBalance(freddy))
-    const FREDDY_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: freddy, gasPrice: GAS_PRICE  }))
-    const freddy_expectedBalance = freddy_balanceBefore.sub(th.toBN(FREDDY_GAS * GAS_PRICE))
-    const freddy_balanceAfter = th.toBN(await web3.eth.getBalance(freddy))
-    th.assertIsApproximatelyEqual(freddy_balanceAfter, freddy_expectedBalance.add(th.toBN(freddy_remainingCollateral)))
+    const freddy_balanceBefore = th.toBN(await erc20Asset1.balanceOf(freddy))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: freddy, gasPrice: GAS_PRICE })
+    const freddy_balanceAfter = th.toBN(await erc20Asset1.balanceOf(freddy))
+    th.assertIsApproximatelyEqual(freddy_balanceAfter, freddy_balanceBefore.add(th.toBN(freddy_remainingCollateral)))
 
-    const greta_balanceBefore = th.toBN(await web3.eth.getBalance(greta))
-    const GRETA_GAS = th.gasUsed(await borrowerOperations.claimCollateral({ from: greta, gasPrice: GAS_PRICE  }))
-    const greta_expectedBalance = greta_balanceBefore.sub(th.toBN(GRETA_GAS * GAS_PRICE))
-    const greta_balanceAfter = th.toBN(await web3.eth.getBalance(greta))
-    th.assertIsApproximatelyEqual(greta_balanceAfter, greta_expectedBalance.add(th.toBN(greta_remainingCollateral)))
+    const greta_balanceBefore = th.toBN(await erc20Asset1.balanceOf(greta))
+    await borrowerOperations.claimCollateral(assetAddress1, { from: greta, gasPrice: GAS_PRICE })
+    const greta_balanceAfter = th.toBN(await erc20Asset1.balanceOf(greta))
+    th.assertIsApproximatelyEqual(greta_balanceAfter, greta_balanceBefore.add(th.toBN(greta_remainingCollateral)))
   })
 
 })

--- a/packages/contracts/test/TroveManager_RecoveryMode_Batch_Liqudation_Test.js
+++ b/packages/contracts/test/TroveManager_RecoveryMode_Batch_Liqudation_Test.js
@@ -1,6 +1,7 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
-const { TestHelper: th, MoneyValues: mv } = require("../utils/testHelpers.js")
+const { TestHelper: th, MoneyValues: mv, TroveData } = require("../utils/testHelpers.js")
 const { toBN, dec, ZERO_ADDRESS } = th
+
 
 const TroveManagerTester = artifacts.require("./TroveManagerTester")
 const KUSDToken = artifacts.require("./KUSDToken.sol")
@@ -19,6 +20,9 @@ contract('TroveManager - in Recovery Mode - back to normal mode in 1 tx', async 
   let stabilityPool
   let priceFeed
   let sortedTroves
+  let KUMOContracts
+  let hardhatTester
+  let erc20Asset1
 
   const openTrove = async (params) => th.openTrove(contracts, params)
 
@@ -30,41 +34,59 @@ contract('TroveManager - in Recovery Mode - back to normal mode in 1 tx', async 
       contracts.stabilityPool.address,
       contracts.borrowerOperations.address
     )
-    const KUMOContracts = await deploymentHelper.deployKUMOContracts(bountyAddress, lpRewardsAddress, multisig)
+    KUMOContracts = await deploymentHelper.deployKUMOContracts(bountyAddress, lpRewardsAddress, multisig)
+    hardhatTester = await deploymentHelper.deployTesterContractsHardhat()
 
     troveManager = contracts.troveManager
     stabilityPool = contracts.stabilityPool
     priceFeed = contracts.priceFeedTestnet
     sortedTroves = contracts.sortedTroves
+    kumoParams = contracts.kumoParameters
+    erc20Asset1 = hardhatTester.erc20
+    assetAddress1 = erc20Asset1.address
 
     await deploymentHelper.connectKUMOContracts(KUMOContracts)
     await deploymentHelper.connectCoreContracts(contracts, KUMOContracts)
     await deploymentHelper.connectKUMOContractsToCore(KUMOContracts, contracts)
+
+    // Add asset to the system
+    await deploymentHelper.addNewAssetToSystem(contracts, KUMOContracts, assetAddress1)
+
+    // Mint token to each acccount
+    let index = 0;
+    for (const acc of accounts) {
+      // await vstaToken.approve(vstaStaking.address, await erc20Asset1.balanceOf(acc), { from: acc })
+      await erc20Asset1.mint(acc, await web3.eth.getBalance(acc))
+      index++;
+
+      if (index >= 20)
+        break;
+    }
   })
 
   context('Batch liquidations', () => {
     const setup = async () => {
-      const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(296, 16)), extraParams: { from: alice } })
-      const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(280, 16)), extraParams: { from: bob } })
-      const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: carol } })
+      const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1,  ICR: toBN(dec(296, 16)), extraParams: { from: alice } })
+      const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1,  ICR: toBN(dec(280, 16)), extraParams: { from: bob } })
+      const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1,  ICR: toBN(dec(150, 16)), extraParams: { from: carol } })
 
       const totalLiquidatedDebt = A_totalDebt.add(B_totalDebt).add(C_totalDebt)
 
-      await openTrove({ ICR: toBN(dec(340, 16)), extraKUSDAmount: totalLiquidatedDebt, extraParams: { from: whale } })
+      await openTrove({ asset: assetAddress1,  ICR: toBN(dec(340, 16)), extraKUSDAmount: totalLiquidatedDebt, extraParams: { from: whale } })
       await stabilityPool.provideToSP(totalLiquidatedDebt, ZERO_ADDRESS, { from: whale })
 
       // Price drops
       await priceFeed.setPrice(dec(100, 18))
       const price = await priceFeed.getPrice()
-      const TCR = await th.getTCR(contracts)
+      const TCR = await th.getTCR(contracts, assetAddress1)
 
       // Check Recovery Mode is active
-      assert.isTrue(await th.checkRecoveryMode(contracts))
+      assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
       // Check troves A, B are in range 110% < ICR < TCR, C is below 100%
-      const ICR_A = await troveManager.getCurrentICR(alice, price)
-      const ICR_B = await troveManager.getCurrentICR(bob, price)
-      const ICR_C = await troveManager.getCurrentICR(carol, price)
+      const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+      const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+      const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
       assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
       assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -81,28 +103,28 @@ contract('TroveManager - in Recovery Mode - back to normal mode in 1 tx', async 
 
     it('First trove only doesn’t get out of Recovery Mode', async () => {
       await setup()
-      const tx = await troveManager.batchLiquidateTroves([alice])
+      const tx = await troveManager.batchLiquidateTroves(assetAddress1, [alice])
 
-      const TCR = await th.getTCR(contracts)
-      assert.isTrue(await th.checkRecoveryMode(contracts))
+      const TCR = await th.getTCR(contracts, assetAddress1)
+      assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
     })
 
     it('Two troves over MCR are liquidated', async () => {
       await setup()
-      const tx = await troveManager.batchLiquidateTroves([alice, bob, carol])
+      const tx = await troveManager.batchLiquidateTroves(assetAddress1, [alice, bob, carol])
 
       const liquidationEvents = th.getAllEventsByName(tx, 'TroveLiquidated')
       assert.equal(liquidationEvents.length, 3, 'Not enough liquidations')
 
       // Confirm all troves removed
-      assert.isFalse(await sortedTroves.contains(alice))
-      assert.isFalse(await sortedTroves.contains(bob))
-      assert.isFalse(await sortedTroves.contains(carol))
+      assert.isFalse(await sortedTroves.contains(assetAddress1,alice))
+      assert.isFalse(await sortedTroves.contains(assetAddress1,bob))
+      assert.isFalse(await sortedTroves.contains(assetAddress1,carol))
 
       // Confirm troves have status 'closed by liquidation' (Status enum element idx 3)
-      assert.equal((await troveManager.Troves(alice))[3], '3')
-      assert.equal((await troveManager.Troves(bob))[3], '3')
-      assert.equal((await troveManager.Troves(carol))[3], '3')
+      assert.equal((await troveManager.Troves(alice, assetAddress1))[TroveData.status], '3')
+      assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status], '3')
+      assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status], '3')
     })
 
     it('Stability Pool profit matches', async () => {
@@ -113,20 +135,20 @@ contract('TroveManager - in Recovery Mode - back to normal mode in 1 tx', async 
         price,
       } = await setup()
 
-      const spEthBefore = await stabilityPool.getETH()
+      const spEthBefore = await stabilityPool.getAssetBalance()
       const spKusdBefore = await stabilityPool.getTotalKUSDDeposits()
 
-      const tx = await troveManager.batchLiquidateTroves([alice, carol])
+      const tx = await troveManager.batchLiquidateTroves(assetAddress1, [alice, carol])
 
       // Confirm all troves removed
-      assert.isFalse(await sortedTroves.contains(alice))
-      assert.isFalse(await sortedTroves.contains(carol))
+      assert.isFalse(await sortedTroves.contains(assetAddress1,alice))
+      assert.isFalse(await sortedTroves.contains(assetAddress1,carol))
 
       // Confirm troves have status 'closed by liquidation' (Status enum element idx 3)
-      assert.equal((await troveManager.Troves(alice))[3], '3')
-      assert.equal((await troveManager.Troves(carol))[3], '3')
+      assert.equal((await troveManager.Troves(alice, assetAddress1))[TroveData.status], '3')
+      assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status], '3')
 
-      const spEthAfter = await stabilityPool.getETH()
+      const spEthAfter = await stabilityPool.getAssetBalance()
       const spKusdAfter = await stabilityPool.getTotalKUSDDeposits()
 
       // liquidate collaterals with the gas compensation fee subtracted
@@ -142,71 +164,71 @@ contract('TroveManager - in Recovery Mode - back to normal mode in 1 tx', async 
     })
 
     it('A trove over TCR is not liquidated', async () => {
-      const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(280, 16)), extraParams: { from: alice } })
-      const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(276, 16)), extraParams: { from: bob } })
-      const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ ICR: toBN(dec(150, 16)), extraParams: { from: carol } })
+      const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1,  ICR: toBN(dec(280, 16)), extraParams: { from: alice } })
+      const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1,  ICR: toBN(dec(276, 16)), extraParams: { from: bob } })
+      const { collateral: C_coll, totalDebt: C_totalDebt } = await openTrove({ asset: assetAddress1,  ICR: toBN(dec(150, 16)), extraParams: { from: carol } })
 
       const totalLiquidatedDebt = A_totalDebt.add(B_totalDebt).add(C_totalDebt)
 
-      await openTrove({ ICR: toBN(dec(310, 16)), extraKUSDAmount: totalLiquidatedDebt, extraParams: { from: whale } })
+      await openTrove({ asset: assetAddress1,  ICR: toBN(dec(310, 16)), extraKUSDAmount: totalLiquidatedDebt, extraParams: { from: whale } })
       await stabilityPool.provideToSP(totalLiquidatedDebt, ZERO_ADDRESS, { from: whale })
 
       // Price drops
       await priceFeed.setPrice(dec(100, 18))
       const price = await priceFeed.getPrice()
-      const TCR = await th.getTCR(contracts)
+      const TCR = await th.getTCR(contracts, assetAddress1)
 
       // Check Recovery Mode is active
-      assert.isTrue(await th.checkRecoveryMode(contracts))
+      assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
       // Check troves A, B are in range 110% < ICR < TCR, C is below 100%
-      const ICR_A = await troveManager.getCurrentICR(alice, price)
-      const ICR_B = await troveManager.getCurrentICR(bob, price)
-      const ICR_C = await troveManager.getCurrentICR(carol, price)
+      const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+      const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
+      const ICR_C = await troveManager.getCurrentICR(assetAddress1, carol, price)
 
       assert.isTrue(ICR_A.gt(TCR))
       assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
       assert.isTrue(ICR_C.lt(mv._ICR100))
 
-      const tx = await troveManager.batchLiquidateTroves([bob, alice])
+      const tx = await troveManager.batchLiquidateTroves(assetAddress1, [bob, alice])
 
       const liquidationEvents = th.getAllEventsByName(tx, 'TroveLiquidated')
       assert.equal(liquidationEvents.length, 1, 'Not enough liquidations')
 
       // Confirm only Bob’s trove removed
-      assert.isTrue(await sortedTroves.contains(alice))
-      assert.isFalse(await sortedTroves.contains(bob))
-      assert.isTrue(await sortedTroves.contains(carol))
+      assert.isTrue(await sortedTroves.contains(assetAddress1,alice))
+      assert.isFalse(await sortedTroves.contains(assetAddress1,bob))
+      assert.isTrue(await sortedTroves.contains(assetAddress1,carol))
 
       // Confirm troves have status 'closed by liquidation' (Status enum element idx 3)
-      assert.equal((await troveManager.Troves(bob))[3], '3')
+      assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status], '3')
       // Confirm troves have status 'open' (Status enum element idx 1)
-      assert.equal((await troveManager.Troves(alice))[3], '1')
-      assert.equal((await troveManager.Troves(carol))[3], '1')
+      assert.equal((await troveManager.Troves(alice, assetAddress1))[TroveData.status], '1')
+      assert.equal((await troveManager.Troves(carol, assetAddress1))[TroveData.status], '1')
     })
   })
 
   context('Sequential liquidations', () => {
     const setup = async () => {
-      const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ ICR: toBN(dec(299, 16)), extraParams: { from: alice } })
-      const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ ICR: toBN(dec(298, 16)), extraParams: { from: bob } })
+      const { collateral: A_coll, totalDebt: A_totalDebt } = await openTrove({ asset: assetAddress1,  ICR: toBN(dec(299, 16)), extraParams: { from: alice } })
+      const { collateral: B_coll, totalDebt: B_totalDebt } = await openTrove({ asset: assetAddress1,  ICR: toBN(dec(298, 16)), extraParams: { from: bob } })
 
       const totalLiquidatedDebt = A_totalDebt.add(B_totalDebt)
 
-      await openTrove({ ICR: toBN(dec(300, 16)), extraKUSDAmount: totalLiquidatedDebt, extraParams: { from: whale } })
+      await openTrove({ asset: assetAddress1,  ICR: toBN(dec(300, 16)), extraKUSDAmount: totalLiquidatedDebt, extraParams: { from: whale } })
       await stabilityPool.provideToSP(totalLiquidatedDebt, ZERO_ADDRESS, { from: whale })
 
       // Price drops
       await priceFeed.setPrice(dec(100, 18))
       const price = await priceFeed.getPrice()
-      const TCR = await th.getTCR(contracts)
+      const TCR = await th.getTCR(contracts, assetAddress1)
 
       // Check Recovery Mode is active
-      assert.isTrue(await th.checkRecoveryMode(contracts))
+      assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
 
       // Check troves A, B are in range 110% < ICR < TCR, C is below 100%
-      const ICR_A = await troveManager.getCurrentICR(alice, price)
-      const ICR_B = await troveManager.getCurrentICR(bob, price)
+      const ICR_A = await troveManager.getCurrentICR(assetAddress1, alice, price)
+      const ICR_B = await troveManager.getCurrentICR(assetAddress1, bob, price)
 
       assert.isTrue(ICR_A.gt(mv._MCR) && ICR_A.lt(TCR))
       assert.isTrue(ICR_B.gt(mv._MCR) && ICR_B.lt(TCR))
@@ -221,26 +243,26 @@ contract('TroveManager - in Recovery Mode - back to normal mode in 1 tx', async 
 
     it('First trove only doesn’t get out of Recovery Mode', async () => {
       await setup()
-      const tx = await troveManager.liquidateTroves(1)
+      const tx = await troveManager.liquidateTroves(assetAddress1, 1)
 
-      const TCR = await th.getTCR(contracts)
-      assert.isTrue(await th.checkRecoveryMode(contracts))
+      const TCR = await th.getTCR(contracts, assetAddress1)
+      assert.isTrue(await th.checkRecoveryMode(contracts, assetAddress1))
     })
 
     it('Two troves over MCR are liquidated', async () => {
       await setup()
-      const tx = await troveManager.liquidateTroves(10)
+      const tx = await troveManager.liquidateTroves(assetAddress1, 10)
 
       const liquidationEvents = th.getAllEventsByName(tx, 'TroveLiquidated')
       assert.equal(liquidationEvents.length, 2, 'Not enough liquidations')
 
       // Confirm all troves removed
-      assert.isFalse(await sortedTroves.contains(alice))
-      assert.isFalse(await sortedTroves.contains(bob))
+      assert.isFalse(await sortedTroves.contains(assetAddress1,alice))
+      assert.isFalse(await sortedTroves.contains(assetAddress1,bob))
 
       // Confirm troves have status 'closed by liquidation' (Status enum element idx 3)
-      assert.equal((await troveManager.Troves(alice))[3], '3')
-      assert.equal((await troveManager.Troves(bob))[3], '3')
+      assert.equal((await troveManager.Troves(alice, assetAddress1))[TroveData.status], '3')
+      assert.equal((await troveManager.Troves(bob, assetAddress1))[TroveData.status], '3')
     })
   })
 })

--- a/packages/contracts/utils/testHelpers.js
+++ b/packages/contracts/utils/testHelpers.js
@@ -191,8 +191,8 @@ class TestHelper {
     return ICR
   }
 
-  static async ICRbetween100and110(account, troveManager, price) {
-    const ICR = await troveManager.getCurrentICR(account, price)
+  static async ICRbetween100and110(asset, account, troveManager, price) {
+    const ICR = await troveManager.getCurrentICR(asset, account, price)
     return (ICR.gt(MoneyValues._ICR100)) && (ICR.lt(MoneyValues._MCR))
   }
 

--- a/packages/contracts/utils/testHelpers.js
+++ b/packages/contracts/utils/testHelpers.js
@@ -517,15 +517,14 @@ class TestHelper {
     return { upperHint, lowerHint }
   }
 
-  static async getEntireCollAndDebt(contracts, account) {
+  static async getEntireCollAndDebt(contracts, asset, account) {
     // console.log(`account: ${account}`)
-    const rawColl = (await contracts.troveManager.Troves(account))[1]
-    const rawDebt = (await contracts.troveManager.Troves(account))[0]
-    const pendingETHReward = await contracts.troveManager.getPendingETHReward(account)
-    const pendingKUSDDebtReward = await contracts.troveManager.getPendingKUSDDebtReward(account)
-    const entireColl = rawColl.add(pendingETHReward)
+    const rawColl = (await contracts.troveManager.Troves(account, asset))[TroveData.coll]
+    const rawDebt = (await contracts.troveManager.Troves(account, asset))[TroveData.debt]
+    const pendingReward = await contracts.troveManager.getPendingReward(asset, account)
+    const pendingKUSDDebtReward = await contracts.troveManager.getPendingKUSDDebtReward(asset, account)
+    const entireColl = rawColl.add(pendingReward)
     const entireDebt = rawDebt.add(pendingKUSDDebtReward)
-
     return { entireColl, entireDebt }
   }
 

--- a/packages/lib-ethers/abi/StabilityPool.json
+++ b/packages/lib-ethers/abi/StabilityPool.json
@@ -130,31 +130,6 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "_depositor",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "_ETH",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "_kusdLoss",
-        "type": "uint256"
-      }
-    ],
-    "name": "ETHGainWithdrawn",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
         "indexed": false,
         "internalType": "uint128",
         "name": "_currentEpoch",
@@ -973,25 +948,6 @@
         "type": "address"
       }
     ],
-    "name": "getDepositorAssetGain1e18",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_depositor",
-        "type": "address"
-      }
-    ],
     "name": "getDepositorKUMOGain",
     "outputs": [
       {
@@ -1153,7 +1109,7 @@
   },
   {
     "inputs": [],
-    "name": "lastkusdLossError_Offset",
+    "name": "lastKUSDLossError_Offset",
     "outputs": [
       {
         "internalType": "uint256",

--- a/packages/lib-ethers/src/PopulatableEthersKumo.ts
+++ b/packages/lib-ethers/src/PopulatableEthersKumo.ts
@@ -69,8 +69,8 @@ const noDetails = () => undefined;
 
 const compose =
   <T, U, V>(f: (_: U) => V, g: (_: T) => U) =>
-  (_: T) =>
-    f(g(_));
+    (_: T) =>
+      f(g(_));
 
 const id = <T>(t: T) => t;
 
@@ -78,8 +78,8 @@ const id = <T>(t: T) => t;
 // decayed baseRate increases logarithmically with time elapsed since the last update.
 const addGasForBaseRateUpdate =
   (maxMinutesSinceLastUpdate = 10) =>
-  (gas: BigNumber) =>
-    gas.add(10000 + 1414 * Math.ceil(Math.log2(maxMinutesSinceLastUpdate + 1)));
+    (gas: BigNumber) =>
+      gas.add(10000 + 1414 * Math.ceil(Math.log2(maxMinutesSinceLastUpdate + 1)));
 
 // First traversal in ascending direction takes ~50K, then ~13.5K per extra step.
 // 80K should be enough for 3 steps, plus some extra to be safe.
@@ -149,9 +149,9 @@ interface RawTransactionFailedError extends Error {
 export interface _RawTransactionReplacedError extends Error {
   code: ErrorCode.TRANSACTION_REPLACED;
   reason:
-    | _RawErrorReason.TRANSACTION_CANCELLED
-    | _RawErrorReason.TRANSACTION_REPLACED
-    | _RawErrorReason.TRANSACTION_REPRICED;
+  | _RawErrorReason.TRANSACTION_CANCELLED
+  | _RawErrorReason.TRANSACTION_REPLACED
+  | _RawErrorReason.TRANSACTION_REPRICED;
   cancelled: boolean;
   hash: string;
   replacement: EthersTransactionResponse;
@@ -202,7 +202,7 @@ export class EthersTransactionCancelledError extends Error {
  */
 export class SentEthersKumoTransaction<T = unknown>
   implements
-    SentKumoTransaction<EthersTransactionResponse, KumoReceipt<EthersTransactionReceipt, T>>
+  SentKumoTransaction<EthersTransactionResponse, KumoReceipt<EthersTransactionReceipt, T>>
 {
   /** Ethers' representation of a sent transaction. */
   readonly rawSentTransaction: EthersTransactionResponse;
@@ -225,8 +225,8 @@ export class SentEthersKumoTransaction<T = unknown>
     return rawReceipt
       ? rawReceipt.status
         ? _successfulReceipt(rawReceipt, this._parse(rawReceipt), () =>
-            logsToString(rawReceipt, _getContracts(this._connection))
-          )
+          logsToString(rawReceipt, _getContracts(this._connection))
+        )
         : _failedReceipt(rawReceipt)
       : _pendingReceipt;
   }
@@ -408,11 +408,11 @@ export class PopulatedEthersKumoTransaction<T = unknown>
 export class PopulatedEthersRedemption
   extends PopulatedEthersKumoTransaction<RedemptionDetails>
   implements
-    PopulatedRedemption<
-      EthersPopulatedTransaction,
-      EthersTransactionResponse,
-      EthersTransactionReceipt
-    >
+  PopulatedRedemption<
+  EthersPopulatedTransaction,
+  EthersTransactionResponse,
+  EthersTransactionReceipt
+  >
 {
   /** {@inheritDoc @kumodao/lib-base#PopulatedRedemption.attemptedKUSDAmount} */
   readonly attemptedKUSDAmount: Decimal;
@@ -467,7 +467,7 @@ export class PopulatedEthersRedemption
     if (!this._increaseAmountByMinimumNetDebt) {
       throw new Error(
         "PopulatedEthersRedemption: increaseAmountByMinimumNetDebt() can " +
-          "only be called when amount is truncated"
+        "only be called when amount is truncated"
       );
     }
 
@@ -489,7 +489,7 @@ export interface _TroveChangeWithFees<T> {
  */
 export class PopulatableEthersKumo
   implements
-    PopulatableKumo<EthersTransactionReceipt, EthersTransactionResponse, EthersPopulatedTransaction>
+  PopulatableKumo<EthersTransactionReceipt, EthersTransactionResponse, EthersPopulatedTransaction>
 {
   private readonly _readable: ReadableEthersKumo;
 
@@ -609,8 +609,8 @@ export class PopulatableEthersKumo
       .map(({ args: { _newDeposit } }) => decimalify(_newDeposit));
 
     const [[collateralGain, kusdLoss]] = stabilityPool
-      .extractEvents(logs, "ETHGainWithdrawn")
-      .map(({ args: { _ETH, _kusdLoss } }) => [decimalify(_ETH), decimalify(_kusdLoss)]);
+      .extractEvents(logs, "AssetGainWithdrawn")
+      .map(({ args: { _Asset, _kusdLoss } }) => [decimalify(_Asset), decimalify(_kusdLoss)]);
 
     const [kumoReward] = stabilityPool
       .extractEvents(logs, "KUMOPaidToDepositor")
@@ -806,10 +806,10 @@ export class PopulatableEthersKumo
       partialRedemptionHintNICR.isZero()
         ? [AddressZero, AddressZero]
         : await this._findHintsForNominalCollateralRatio(
-            asset,
-            decimalify(partialRedemptionHintNICR)
-            // XXX: if we knew the partially redeemed Trove's address, we'd pass it here
-          );
+          asset,
+          decimalify(partialRedemptionHintNICR)
+          // XXX: if we knew the partially redeemed Trove's address, we'd pass it here
+        );
 
     return [
       decimalify(truncatedKUSDamount),
@@ -877,7 +877,7 @@ export class PopulatableEthersKumo
       if (decayedTrove.debt.lt(KUSD_MINIMUM_DEBT)) {
         throw new Error(
           `Trove's debt might fall below ${KUSD_MINIMUM_DEBT} ` +
-            `within ${borrowingFeeDecayToleranceMinutes} minutes`
+          `within ${borrowingFeeDecayToleranceMinutes} minutes`
         );
       }
 
@@ -966,12 +966,12 @@ export class PopulatableEthersKumo
     const [trove, feeVars] = await Promise.all([
       this._readable.getTrove(address),
       borrowKUSD &&
-        promiseAllValues({
-          fees: this._readable._getFeesFactory(asset),
-          blockTimestamp: this._readable._getBlockTimestamp(),
-          total: this._readable.getTotal(asset),
-          price: this._readable.getPrice()
-        })
+      promiseAllValues({
+        fees: this._readable._getFeesFactory(asset),
+        blockTimestamp: this._readable._getBlockTimestamp(),
+        total: this._readable.getTotal(asset),
+        price: this._readable.getPrice()
+      })
     ]);
 
     const decayBorrowingRate = (seconds: number) =>
@@ -1016,14 +1016,14 @@ export class PopulatableEthersKumo
       if (decayedTrove.debt.lt(KUSD_MINIMUM_DEBT)) {
         throw new Error(
           `Trove's debt might fall below ${KUSD_MINIMUM_DEBT} ` +
-            `within ${borrowingFeeDecayToleranceMinutes} minutes`
+          `within ${borrowingFeeDecayToleranceMinutes} minutes`
         );
       }
 
       const [gasNow, gasLater] = await Promise.all([
         borrowerOperations.estimateGas.adjustTrove(...txParams(borrowKUSD)),
         borrowKUSD &&
-          borrowerOperations.estimateGas.adjustTrove(...txParams(borrowKUSDSimulatingDecay))
+        borrowerOperations.estimateGas.adjustTrove(...txParams(borrowKUSDSimulatingDecay))
       ]);
 
       let gasLimit = bigNumberMax(addGasForPotentialListTraversal(gasNow), gasLater);
@@ -1289,11 +1289,11 @@ export class PopulatableEthersKumo
 
         truncatedAmount.lt(attemptedKUSDAmount)
           ? newMaxRedemptionRate =>
-              populateRedemption(
-                asset,
-                truncatedAmount.add(KUSD_MINIMUM_NET_DEBT),
-                newMaxRedemptionRate ?? maxRedemptionRate
-              )
+            populateRedemption(
+              asset,
+              truncatedAmount.add(KUSD_MINIMUM_NET_DEBT),
+              newMaxRedemptionRate ?? maxRedemptionRate
+            )
           : undefined
       );
     };

--- a/packages/lib-ethers/types/index.ts
+++ b/packages/lib-ethers/types/index.ts
@@ -679,7 +679,6 @@ interface StabilityPoolCalls {
   getCompoundedKUSDDeposit(_depositor: string, _overrides?: CallOverrides): Promise<BigNumber>;
   getCompoundedTotalStake(_overrides?: CallOverrides): Promise<BigNumber>;
   getDepositorAssetGain(_depositor: string, _overrides?: CallOverrides): Promise<BigNumber>;
-  getDepositorAssetGain1e18(_depositor: string, _overrides?: CallOverrides): Promise<BigNumber>;
   getDepositorKUMOGain(_depositor: string, _overrides?: CallOverrides): Promise<BigNumber>;
   getEntireSystemColl(_asset: string, _overrides?: CallOverrides): Promise<BigNumber>;
   getEntireSystemDebt(_asset: string, _overrides?: CallOverrides): Promise<BigNumber>;
@@ -691,7 +690,7 @@ interface StabilityPoolCalls {
   kusdToken(_overrides?: CallOverrides): Promise<string>;
   lastETHError_Offset(_overrides?: CallOverrides): Promise<BigNumber>;
   lastKUMOError(_overrides?: CallOverrides): Promise<BigNumber>;
-  lastkusdLossError_Offset(_overrides?: CallOverrides): Promise<BigNumber>;
+  lastKUSDLossError_Offset(_overrides?: CallOverrides): Promise<BigNumber>;
   owner(_overrides?: CallOverrides): Promise<string>;
   sortedTroves(_overrides?: CallOverrides): Promise<string>;
   systemSnapshots(_overrides?: CallOverrides): Promise<{ S: BigNumber; P: BigNumber; G: BigNumber; scale: BigNumber; epoch: BigNumber }>;
@@ -720,7 +719,6 @@ export interface StabilityPool
     CommunityIssuanceAddressChanged(_newCommunityIssuanceAddress?: null): EventFilter;
     DefaultPoolAddressChanged(_newDefaultPoolAddress?: null): EventFilter;
     DepositSnapshotUpdated(_depositor?: string | null, _P?: null, _S?: null, _G?: null): EventFilter;
-    ETHGainWithdrawn(_depositor?: string | null, _ETH?: null, _kusdLoss?: null): EventFilter;
     EpochUpdated(_currentEpoch?: null): EventFilter;
     FrontEndRegistered(_frontEnd?: string | null, _kickbackRate?: null): EventFilter;
     FrontEndSnapshotUpdated(_frontEnd?: string | null, _P?: null, _G?: null): EventFilter;
@@ -751,7 +749,6 @@ export interface StabilityPool
   extractEvents(logs: Log[], name: "CommunityIssuanceAddressChanged"): _TypedLogDescription<{ _newCommunityIssuanceAddress: string }>[];
   extractEvents(logs: Log[], name: "DefaultPoolAddressChanged"): _TypedLogDescription<{ _newDefaultPoolAddress: string }>[];
   extractEvents(logs: Log[], name: "DepositSnapshotUpdated"): _TypedLogDescription<{ _depositor: string; _P: BigNumber; _S: BigNumber; _G: BigNumber }>[];
-  extractEvents(logs: Log[], name: "ETHGainWithdrawn"): _TypedLogDescription<{ _depositor: string; _ETH: BigNumber; _kusdLoss: BigNumber }>[];
   extractEvents(logs: Log[], name: "EpochUpdated"): _TypedLogDescription<{ _currentEpoch: BigNumber }>[];
   extractEvents(logs: Log[], name: "FrontEndRegistered"): _TypedLogDescription<{ _frontEnd: string; _kickbackRate: BigNumber }>[];
   extractEvents(logs: Log[], name: "FrontEndSnapshotUpdated"): _TypedLogDescription<{ _frontEnd: string; _P: BigNumber; _G: BigNumber }>[];

--- a/packages/subgraph/subgraph.yaml.js
+++ b/packages/subgraph/subgraph.yaml.js
@@ -129,7 +129,7 @@ dataSources:
       eventHandlers:
         - event: UserDepositChanged(indexed address,uint256)
           handler: handleUserDepositChanged
-        - event: ETHGainWithdrawn(indexed address,uint256,uint256)
+        - event: AssetGainWithdrawn(indexed address,uint256,uint256)
           handler: handleETHGainWithdrawn
         - event: FrontEndRegistered(indexed address,uint256)
           handler: handleFrontendRegistered


### PR DESCRIPTION
- Implements `asset` in all TroveManager RecoveryMode Batch Liquidation Tests #229 
- Implements `asset` in TrovManager Recovery Mode Tests #228
- removed `ETH` from the `StabilityPool` and only uses `asset` functions
- Switched from `ETH...` to `AssetGainWithdrawn` in `StabilityPool`, `lib-ethers`, and `subgraph`

Merge PR #236 before this PR