### PR TITLE
ci: restricting SDK build runs

### DIFF
--- a/.github/workflows/generic-skip.yaml
+++ b/.github/workflows/generic-skip.yaml
@@ -1,4 +1,4 @@
-name: Test contracts
+name: Test contracts (Generic Skip)
 # Handles skipped but required checks
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,40 @@ env:
   CI: true
   FORCE_COLOR: true
 
-on: [ push, pull_request ]
+on:
+  push:
+    paths-ignore:
+      # In future file changes, we can delete the following line
+      # and uncomment the one below. 
+      - ".github/**"
+      # - ".github/workflows/release.yml"
+      - 'docs/**'
+      - 'packages/contracts/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'papers/**'
+      - 'images/**'
+  pull_request:
+    paths-ignore:
+      # In future file changes, we can delete the following line
+      # and uncomment the one below. 
+      - ".github/**"
+      # - ".github/workflows/release.yml"
+      - 'docs/**'
+      - 'packages/contracts/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'papers/**'
+      - 'images/**'
 
 jobs:
   workflow-setup:
     name: Initialize Workflow
     runs-on: ubuntu-latest
+
+    # This condition checks if the pull request is not a draft
+    if: github.event.pull_request.draft == false
+
     outputs: 
       publish: ${{ steps.build-flags.outputs.publish }}
     steps:

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -7,16 +7,21 @@ env:
 on:
   push:
     paths:
-      - ".github/**"
+      # In future file changes, we can uncomment the following line
+      # - ".github/workflows/test-contracts.yml"
       - "packages/contracts/**"
   pull_request:
     paths:
-      - ".github/**"
+      # In future file changes, we can uncomment the following line
+      # - ".github/workflows/test-contracts.yml"
       - "packages/contracts/**"
 
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    # This condition checks if the pull request is not a draft
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The SDK is currently being built in every PR and additional commit pushes, which slows down development speed significantly.

Here a few directories are excluded, like documentation and the contract package.

This should be improved in the future to only **include** the paths for the SDK and frontend.