### PR TITLE
build(sol): update to a newer sol version

### DIFF
--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 

--- a/packages/contracts/contracts/CollSurplusPool.sol
+++ b/packages/contracts/contracts/CollSurplusPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/DefaultPool.sol
+++ b/packages/contracts/contracts/DefaultPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/Dependencies/AggregatorV3Interface.sol
+++ b/packages/contracts/contracts/Dependencies/AggregatorV3Interface.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Code from https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 interface AggregatorV3Interface {
     function decimals() external view returns (uint8);

--- a/packages/contracts/contracts/Dependencies/BaseMath.sol
+++ b/packages/contracts/contracts/Dependencies/BaseMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 
 contract BaseMath {

--- a/packages/contracts/contracts/Dependencies/CheckContract.sol
+++ b/packages/contracts/contracts/Dependencies/CheckContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 
 contract CheckContract {

--- a/packages/contracts/contracts/Dependencies/IERC20.sol
+++ b/packages/contracts/contracts/Dependencies/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 /**
  * Based on the OpenZeppelin IER20 interface:

--- a/packages/contracts/contracts/Dependencies/IERC2612.sol
+++ b/packages/contracts/contracts/Dependencies/IERC2612.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 /**
  * @dev Interface of the ERC2612 standard as defined in the EIP.

--- a/packages/contracts/contracts/Dependencies/ITellor.sol
+++ b/packages/contracts/contracts/Dependencies/ITellor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 interface ITellor {
     /**

--- a/packages/contracts/contracts/Dependencies/KumoBase.sol
+++ b/packages/contracts/contracts/Dependencies/KumoBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/Dependencies/KumoMath.sol
+++ b/packages/contracts/contracts/Dependencies/KumoMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // import "./SafeMath.sol";
 

--- a/packages/contracts/contracts/Dependencies/KumoSafeMath128.sol
+++ b/packages/contracts/contracts/Dependencies/KumoSafeMath128.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // uint128 addition and subtraction, with overflow protection.
 

--- a/packages/contracts/contracts/Dependencies/Ownable.sol
+++ b/packages/contracts/contracts/Dependencies/Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 /**
  * Based on OpenZeppelin's Ownable contract:

--- a/packages/contracts/contracts/Dependencies/SafeMath.sol
+++ b/packages/contracts/contracts/Dependencies/SafeMath.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts v4.4.1 (utils/math/SafeMath.sol)
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 // CAUTION
 // This version of SafeMath should only be used with Solidity 0.8 or later,
 // because it relies on the compiler's built in overflow checks.

--- a/packages/contracts/contracts/Dependencies/SafetyTransfer.sol
+++ b/packages/contracts/contracts/Dependencies/SafetyTransfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./IERC20.sol";
 import "./SafeMath.sol";

--- a/packages/contracts/contracts/Dependencies/TellorCaller.sol
+++ b/packages/contracts/contracts/Dependencies/TellorCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/ITellorCaller.sol";
 import "./ITellor.sol";

--- a/packages/contracts/contracts/DiamondInit.sol
+++ b/packages/contracts/contracts/DiamondInit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 /******************************************************************************\
 * Author: Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)

--- a/packages/contracts/contracts/Facets/CDPManagerTesterFacet.sol
+++ b/packages/contracts/contracts/Facets/CDPManagerTesterFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/IKumoParameters.sol";
 import "../Dependencies/KumoMath.sol";

--- a/packages/contracts/contracts/Facets/DiamondCutFacet.sol
+++ b/packages/contracts/contracts/Facets/DiamondCutFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 /******************************************************************************\
 * Author: Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)

--- a/packages/contracts/contracts/Facets/DiamondLoupeFacet.sol
+++ b/packages/contracts/contracts/Facets/DiamondLoupeFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 /******************************************************************************\
 * Author: Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)
 * EIP-2535 Diamonds: https://eips.ethereum.org/EIPS/eip-2535

--- a/packages/contracts/contracts/Facets/OwnershipFacet.sol
+++ b/packages/contracts/contracts/Facets/OwnershipFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 import {LibDiamond} from "../Libraries/LibDiamond.sol";
 import {IERC173} from "../Interfaces/IERC173.sol";

--- a/packages/contracts/contracts/Facets/TroveManagerFacet.sol
+++ b/packages/contracts/contracts/Facets/TroveManagerFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/Facets/ITroveManagerFacet.sol";
 import "../Interfaces/IKumoParameters.sol";

--- a/packages/contracts/contracts/Facets/TroveRedemptorFacet.sol
+++ b/packages/contracts/contracts/Facets/TroveRedemptorFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/Facets/ITroveRedemptorFacet.sol";
 import "../Interfaces/IStabilityPool.sol";

--- a/packages/contracts/contracts/GasPool.sol
+++ b/packages/contracts/contracts/GasPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 
 /**

--- a/packages/contracts/contracts/HintHelpers.sol
+++ b/packages/contracts/contracts/HintHelpers.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./Interfaces/ITroveManagerDiamond.sol";
 import "./Interfaces/ISortedTroves.sol";

--- a/packages/contracts/contracts/Interfaces/Facets/ITroveManagerFacet.sol
+++ b/packages/contracts/contracts/Interfaces/Facets/ITroveManagerFacet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import {Trove, RewardSnapshot} from "../../Libraries/LibAppStorage.sol";
 import "../ICollSurplusPool.sol";

--- a/packages/contracts/contracts/Interfaces/Facets/ITroveRedemptorFacet.sol
+++ b/packages/contracts/contracts/Interfaces/Facets/ITroveRedemptorFacet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 // Common interface for the Trove Redemptor.
 interface ITroveRedemptorFacet {

--- a/packages/contracts/contracts/Interfaces/IActivePool.sol
+++ b/packages/contracts/contracts/Interfaces/IActivePool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./IPool.sol";
 

--- a/packages/contracts/contracts/Interfaces/IBorrowerOperations.sol
+++ b/packages/contracts/contracts/Interfaces/IBorrowerOperations.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // Common interface for the Trove Manager.
 interface IBorrowerOperations {

--- a/packages/contracts/contracts/Interfaces/ICollSurplusPool.sol
+++ b/packages/contracts/contracts/Interfaces/ICollSurplusPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./IDeposit.sol";
 

--- a/packages/contracts/contracts/Interfaces/ICommunityIssuance.sol
+++ b/packages/contracts/contracts/Interfaces/ICommunityIssuance.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 interface ICommunityIssuance {
     // --- Events ---

--- a/packages/contracts/contracts/Interfaces/IDefaultPool.sol
+++ b/packages/contracts/contracts/Interfaces/IDefaultPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./IPool.sol";
 

--- a/packages/contracts/contracts/Interfaces/IDeposit.sol
+++ b/packages/contracts/contracts/Interfaces/IDeposit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 interface IDeposit {
 	function receivedERC20(address _asset, uint256 _amount) external;

--- a/packages/contracts/contracts/Interfaces/IDiamondCut.sol
+++ b/packages/contracts/contracts/Interfaces/IDiamondCut.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 /******************************************************************************\
 * Author: Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)

--- a/packages/contracts/contracts/Interfaces/IDiamondLoupe.sol
+++ b/packages/contracts/contracts/Interfaces/IDiamondLoupe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 /******************************************************************************\
 * Author: Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)

--- a/packages/contracts/contracts/Interfaces/IERC165.sol
+++ b/packages/contracts/contracts/Interfaces/IERC165.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 interface IERC165 {
     /// @notice Query if a contract implements an interface

--- a/packages/contracts/contracts/Interfaces/IERC173.sol
+++ b/packages/contracts/contracts/Interfaces/IERC173.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 /// @title ERC-173 Contract Ownership Standard
 ///  Note: the ERC-165 identifier for this interface is 0x7f5828d0

--- a/packages/contracts/contracts/Interfaces/IKUMOStaking.sol
+++ b/packages/contracts/contracts/Interfaces/IKUMOStaking.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 

--- a/packages/contracts/contracts/Interfaces/IKUMOToken.sol
+++ b/packages/contracts/contracts/Interfaces/IKUMOToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/IERC20.sol";
 import "../Dependencies/IERC2612.sol";

--- a/packages/contracts/contracts/Interfaces/IKUSDToken.sol
+++ b/packages/contracts/contracts/Interfaces/IKUSDToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/IERC20.sol";
 import "../Dependencies/IERC2612.sol";

--- a/packages/contracts/contracts/Interfaces/IKumoBase.sol
+++ b/packages/contracts/contracts/Interfaces/IKumoBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./IPriceFeed.sol";
 import "./IKumoParameters.sol";

--- a/packages/contracts/contracts/Interfaces/IKumoParameters.sol
+++ b/packages/contracts/contracts/Interfaces/IKumoParameters.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 import "./IActivePool.sol";
 import "./IBorrowerOperations.sol";

--- a/packages/contracts/contracts/Interfaces/ILockupContractFactory.sol
+++ b/packages/contracts/contracts/Interfaces/ILockupContractFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
     
 interface ILockupContractFactory {
     

--- a/packages/contracts/contracts/Interfaces/IPool.sol
+++ b/packages/contracts/contracts/Interfaces/IPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./IDeposit.sol";
 

--- a/packages/contracts/contracts/Interfaces/IPriceFeed.sol
+++ b/packages/contracts/contracts/Interfaces/IPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 interface IPriceFeed {
 

--- a/packages/contracts/contracts/Interfaces/ISortedTroves.sol
+++ b/packages/contracts/contracts/Interfaces/ISortedTroves.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // Common interface for the SortedTroves Doubly Linked List.
 interface ISortedTroves {

--- a/packages/contracts/contracts/Interfaces/IStabilityPool.sol
+++ b/packages/contracts/contracts/Interfaces/IStabilityPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./IDeposit.sol";
 

--- a/packages/contracts/contracts/Interfaces/IStabilityPoolFactory.sol
+++ b/packages/contracts/contracts/Interfaces/IStabilityPoolFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./IStabilityPool.sol";
 

--- a/packages/contracts/contracts/Interfaces/ITellorCaller.sol
+++ b/packages/contracts/contracts/Interfaces/ITellorCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 interface ITellorCaller {
     function getTellorCurrentValue(bytes32 _queryId) external view returns (bool, uint256, uint256);

--- a/packages/contracts/contracts/Interfaces/ITroveManagerDiamond.sol
+++ b/packages/contracts/contracts/Interfaces/ITroveManagerDiamond.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./Facets/ITroveManagerFacet.sol";
 import "./Facets/ITroveRedemptorFacet.sol";

--- a/packages/contracts/contracts/KUMO/CommunityIssuance.sol
+++ b/packages/contracts/contracts/KUMO/CommunityIssuance.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/KUMO/KUMOStaking.sol
+++ b/packages/contracts/contracts/KUMO/KUMOStaking.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/KUMO/KUMOToken.sol
+++ b/packages/contracts/contracts/KUMO/KUMOToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/CheckContract.sol";
 import "../Dependencies/SafeMath.sol";

--- a/packages/contracts/contracts/KUMO/LockupContract.sol
+++ b/packages/contracts/contracts/KUMO/LockupContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/SafeMath.sol";
 import "../Interfaces/IKUMOToken.sol";

--- a/packages/contracts/contracts/KUMO/LockupContractFactory.sol
+++ b/packages/contracts/contracts/KUMO/LockupContractFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/KUSDToken.sol
+++ b/packages/contracts/contracts/KUSDToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./Interfaces/IKUSDToken.sol";
 import "./Interfaces/IStabilityPoolFactory.sol";

--- a/packages/contracts/contracts/KumoFaucet.sol
+++ b/packages/contracts/contracts/KumoFaucet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/contracts/contracts/KumoParameters.sol
+++ b/packages/contracts/contracts/KumoParameters.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/LPRewards/Dependencies/Address.sol
+++ b/packages/contracts/contracts/LPRewards/Dependencies/Address.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 /**
  * @dev Collection of functions related to the address type

--- a/packages/contracts/contracts/LPRewards/Dependencies/SafeERC20.sol
+++ b/packages/contracts/contracts/LPRewards/Dependencies/SafeERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../../Dependencies/IERC20.sol";
 import "../../Dependencies/SafeMath.sol";

--- a/packages/contracts/contracts/LPRewards/Interfaces/ILPTokenWrapper.sol
+++ b/packages/contracts/contracts/LPRewards/Interfaces/ILPTokenWrapper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 
 interface ILPTokenWrapper {

--- a/packages/contracts/contracts/LPRewards/Interfaces/IUnipool.sol
+++ b/packages/contracts/contracts/LPRewards/Interfaces/IUnipool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 
 interface IUnipool {

--- a/packages/contracts/contracts/LPRewards/TestContracts/ERC20Mock.sol
+++ b/packages/contracts/contracts/LPRewards/TestContracts/ERC20Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/contracts/contracts/LPRewards/Unipool.sol
+++ b/packages/contracts/contracts/LPRewards/Unipool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/Libraries/LibAppStorage.sol
+++ b/packages/contracts/contracts/Libraries/LibAppStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Libraries/LibDiamond.sol";
 import "../Interfaces/ICollSurplusPool.sol";

--- a/packages/contracts/contracts/Libraries/LibDiamond.sol
+++ b/packages/contracts/contracts/Libraries/LibDiamond.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 /******************************************************************************\
 * Author: Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)

--- a/packages/contracts/contracts/Libraries/LibKumoBase.sol
+++ b/packages/contracts/contracts/Libraries/LibKumoBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import {LibAppStorage, AppStorage} from "./LibAppStorage.sol";
 import "../Dependencies/KumoMath.sol";

--- a/packages/contracts/contracts/Libraries/LibMeta.sol
+++ b/packages/contracts/contracts/Libraries/LibMeta.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 /******************************************************************************\
 * Author: Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)

--- a/packages/contracts/contracts/Libraries/LibTroveManager.sol
+++ b/packages/contracts/contracts/Libraries/LibTroveManager.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import {LibAppStorage, AppStorage, Status} from "./LibAppStorage.sol";
 import {LibKumoBase} from "./LibKumoBase.sol";

--- a/packages/contracts/contracts/MultiTroveGetter.sol
+++ b/packages/contracts/contracts/MultiTroveGetter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 import {Trove, RewardSnapshot} from "./Libraries/LibAppStorage.sol";
 import "./Interfaces/ITroveManagerDiamond.sol";

--- a/packages/contracts/contracts/PriceFeed.sol
+++ b/packages/contracts/contracts/PriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/Proxy/BorrowerOperationsScript.sol
+++ b/packages/contracts/contracts/Proxy/BorrowerOperationsScript.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/CheckContract.sol";
 import "../Interfaces/IBorrowerOperations.sol";

--- a/packages/contracts/contracts/Proxy/BorrowerWrappersScript.sol
+++ b/packages/contracts/contracts/Proxy/BorrowerWrappersScript.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/SafeMath.sol";
 import "../Dependencies/KumoMath.sol";

--- a/packages/contracts/contracts/Proxy/ETHTransferScript.sol
+++ b/packages/contracts/contracts/Proxy/ETHTransferScript.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 
 contract ETHTransferScript {

--- a/packages/contracts/contracts/Proxy/KUMOStakingScript.sol
+++ b/packages/contracts/contracts/Proxy/KUMOStakingScript.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/CheckContract.sol";
 import "../Interfaces/IKUMOStaking.sol";

--- a/packages/contracts/contracts/Proxy/StabilityPoolScript.sol
+++ b/packages/contracts/contracts/Proxy/StabilityPoolScript.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/CheckContract.sol";
 import "../Interfaces/IStabilityPool.sol";

--- a/packages/contracts/contracts/Proxy/TokenScript.sol
+++ b/packages/contracts/contracts/Proxy/TokenScript.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/CheckContract.sol";
 import "../Dependencies/IERC20.sol";

--- a/packages/contracts/contracts/Proxy/TroveManagerScript.sol
+++ b/packages/contracts/contracts/Proxy/TroveManagerScript.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/CheckContract.sol";
 import "../Interfaces/ITroveManagerDiamond.sol";

--- a/packages/contracts/contracts/SortedTroves.sol
+++ b/packages/contracts/contracts/SortedTroves.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 // import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 

--- a/packages/contracts/contracts/StabilityPoolFactory.sol
+++ b/packages/contracts/contracts/StabilityPoolFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "./Dependencies/Ownable.sol";
 import "./Interfaces/IStabilityPool.sol";

--- a/packages/contracts/contracts/TestContracts/ActivePoolTester.sol
+++ b/packages/contracts/contracts/TestContracts/ActivePoolTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../ActivePool.sol";
 

--- a/packages/contracts/contracts/TestContracts/BorrowerOperationsTester.sol
+++ b/packages/contracts/contracts/TestContracts/BorrowerOperationsTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../BorrowerOperations.sol";
 

--- a/packages/contracts/contracts/TestContracts/CommunityIssuanceTester.sol
+++ b/packages/contracts/contracts/TestContracts/CommunityIssuanceTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../KUMO/CommunityIssuance.sol";
 

--- a/packages/contracts/contracts/TestContracts/DappSys/proxy.sol
+++ b/packages/contracts/contracts/TestContracts/DappSys/proxy.sol
@@ -20,7 +20,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.8.11;
+pragma solidity 0.8.15;
 
 abstract contract DSAuthority {
     function canCall(

--- a/packages/contracts/contracts/TestContracts/DefaultPoolTester.sol
+++ b/packages/contracts/contracts/TestContracts/DefaultPoolTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../DefaultPool.sol";
 

--- a/packages/contracts/contracts/TestContracts/Destructible.sol
+++ b/packages/contracts/contracts/TestContracts/Destructible.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 contract Destructible {
     

--- a/packages/contracts/contracts/TestContracts/ERC20Test.sol
+++ b/packages/contracts/contracts/TestContracts/ERC20Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";

--- a/packages/contracts/contracts/TestContracts/EchidnaProxy.sol
+++ b/packages/contracts/contracts/TestContracts/EchidnaProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/ITroveManagerDiamond.sol";
 import "../BorrowerOperations.sol";

--- a/packages/contracts/contracts/TestContracts/EchidnaTester.sol
+++ b/packages/contracts/contracts/TestContracts/EchidnaTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../TroveManagerDiamond.sol";
 import "../BorrowerOperations.sol";

--- a/packages/contracts/contracts/TestContracts/FunctionCaller.sol
+++ b/packages/contracts/contracts/TestContracts/FunctionCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/ITroveManagerDiamond.sol";
 import "../Interfaces/ISortedTroves.sol";

--- a/packages/contracts/contracts/TestContracts/KUMOStakingTester.sol
+++ b/packages/contracts/contracts/TestContracts/KUMOStakingTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../KUMO/KUMOStaking.sol";
 

--- a/packages/contracts/contracts/TestContracts/KUMOTokenTester.sol
+++ b/packages/contracts/contracts/TestContracts/KUMOTokenTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../KUMO/KUMOToken.sol";
 

--- a/packages/contracts/contracts/TestContracts/KUSDTokenCaller.sol
+++ b/packages/contracts/contracts/TestContracts/KUSDTokenCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/IKUSDToken.sol";
 

--- a/packages/contracts/contracts/TestContracts/KUSDTokenTester.sol
+++ b/packages/contracts/contracts/TestContracts/KUSDTokenTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../KUSDToken.sol";
 

--- a/packages/contracts/contracts/TestContracts/LiquityMathTester.sol
+++ b/packages/contracts/contracts/TestContracts/LiquityMathTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/KumoMath.sol";
 

--- a/packages/contracts/contracts/TestContracts/LiquitySafeMath128Tester.sol
+++ b/packages/contracts/contracts/TestContracts/LiquitySafeMath128Tester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/KumoSafeMath128.sol";
 

--- a/packages/contracts/contracts/TestContracts/MockAggregator.sol
+++ b/packages/contracts/contracts/TestContracts/MockAggregator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Dependencies/AggregatorV3Interface.sol";
 import "hardhat/console.sol";

--- a/packages/contracts/contracts/TestContracts/MockTellor.sol
+++ b/packages/contracts/contracts/TestContracts/MockTellor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 
 contract MockTellor {

--- a/packages/contracts/contracts/TestContracts/NonPayable.sol
+++ b/packages/contracts/contracts/TestContracts/NonPayable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 //import "hardhat/console.sol";
 

--- a/packages/contracts/contracts/TestContracts/PriceFeedTester.sol
+++ b/packages/contracts/contracts/TestContracts/PriceFeedTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../PriceFeed.sol";
 

--- a/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
+++ b/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/IPriceFeed.sol";
 

--- a/packages/contracts/contracts/TestContracts/SortedTrovesTester.sol
+++ b/packages/contracts/contracts/TestContracts/SortedTrovesTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../Interfaces/ISortedTroves.sol";
 

--- a/packages/contracts/contracts/TestContracts/StabilityPoolTester.sol
+++ b/packages/contracts/contracts/TestContracts/StabilityPoolTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 import "../StabilityPool.sol";
 

--- a/packages/contracts/contracts/TroveManagerDiamond.sol
+++ b/packages/contracts/contracts/TroveManagerDiamond.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.11;
+pragma solidity 0.8.15;
 
 /******************************************************************************\
 * Author: Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)

--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -44,7 +44,7 @@ module.exports = {
   solidity: {
     compilers: [
       {
-        version: "0.8.11",
+        version: "0.8.15",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
In line with security best practices, all pragma statements are changed to the latest stable solidity version 0.8.21. The statement omits the caret and tilde so that there is less ambiguity about the version in which the code was compiled.


Solves issue: https://github.com/kumodao/kumo-protocol/issues/343