### PR TITLE
Update synpress package and skip flaky tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
   "resolutions": {
     "react-error-overlay": "6.0.9",
     "@types/react": "^17.0.3",
-    "@types/react-dom": "^18.0.2",
-    "cypress": "^12.14.0"
+    "@types/react-dom": "^18.0.2"
   }
 }

--- a/packages/dev-frontend/package.json
+++ b/packages/dev-frontend/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "devDependencies": {
-    "@synthetixio/synpress": "^3.7.2-beta.5",
+    "@synthetixio/synpress": "^3.7.2-beta.6",
     "cypress": "^12.14.0",
     "start-server-and-test": "^2.0.0"
   }

--- a/packages/dev-frontend/tests/e2e/specs/kumo-app-e2e-testing.js
+++ b/packages/dev-frontend/tests/e2e/specs/kumo-app-e2e-testing.js
@@ -131,7 +131,7 @@ describe('KUMO App e2e testing spec', () => {
     cy.contains('ADJUST').should('be.visible');
   })
 
-  it('Alice should adjust KUSD in NBC Stability Pool', () => {
+  it.skip('Alice should adjust KUSD in NBC Stability Pool', () => {
     cy.visit('/');
     cy.reload();
     cy.contains('CONNECT').click();
@@ -234,7 +234,7 @@ describe('KUMO App e2e testing spec', () => {
     cy.contains('ADJUST').should('be.visible');
   })
 
-  it('Alice should adjust KUSD in CSC Stability Pool', () => {
+  it.skip('Alice should adjust KUSD in CSC Stability Pool', () => {
     cy.visit('/');
     cy.reload();
     cy.contains('CONNECT').click();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,6 +1429,30 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
+"@cypress/request@^2.88.11":
+  version "2.88.12"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
+  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    http-signature "~1.3.6"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    performance-now "^2.1.0"
+    qs "~6.10.3"
+    safe-buffer "^5.1.2"
+    tough-cookie "^4.1.3"
+    tunnel-agent "^0.6.0"
+    uuid "^8.3.2"
+
 "@cypress/webpack-dev-server@^3.5.2":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/@cypress/webpack-dev-server/-/webpack-dev-server-3.5.3.tgz#5fcbb158f23a95989be6fc6c33419901d89cb467"
@@ -4305,10 +4329,10 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
-"@synthetixio/synpress@^3.7.2-beta.5":
-  version "3.7.2-beta.5"
-  resolved "https://registry.yarnpkg.com/@synthetixio/synpress/-/synpress-3.7.2-beta.5.tgz#b89e8b8bad3e411d6c46ef6c19aab1d40621e500"
-  integrity sha512-t0bTNsep7Pz/KYWzbdUrzPG6YFpR3bZ7O5AVMC2oiTxPC99fFob9HIiQWMNQq9oWMskJiyCm+7b4d5tGCEIh2g==
+"@synthetixio/synpress@^3.7.2-beta.6":
+  version "3.7.2-beta.7"
+  resolved "https://registry.yarnpkg.com/@synthetixio/synpress/-/synpress-3.7.2-beta.7.tgz#80a485c15c28de08f9b9e6219e38493b1122bf9c"
+  integrity sha512-V5Z59fbzMIv3BVjzfMElD+eR+3C1q3mKPR6RJh9C0GpAnsBLtH2c2cPgBV2QgHBdmaJLFxEQBBud6Sb05w2jcw==
   dependencies:
     "@cypress/code-coverage" "^3.11.0"
     "@cypress/webpack-dev-server" "^3.5.2"
@@ -4328,7 +4352,7 @@
     babel-plugin-transform-react-styled-components-qa "^2.1.0"
     bytes32 "^0.0.3"
     commander "^11.0.0"
-    cypress "^12.17.4"
+    cypress "12.17.3"
     cypress-wait-until "^2.0.1"
     debug "^4.3.4"
     dotenv "^16.3.1"
@@ -5150,6 +5174,11 @@
   version "14.18.51"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.51.tgz#cb90935b89c641201c3d07a595c3e22d1cfaa417"
   integrity sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA==
+
+"@types/node@^16.18.39":
+  version "16.18.48"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.48.tgz#3bc872236cdb31cb51024d8875d655e25db489a4"
+  integrity sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==
 
 "@types/node@^8.0.0":
   version "8.10.66"
@@ -9651,7 +9680,7 @@ cypress-wait-until@^2.0.1:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-2.0.1.tgz#69c575c7207d83e4ae023e2aaecf2b66148c9fc0"
   integrity sha512-+IyVnYNiaX1+C+V/LazrJWAi/CqiwfNoRSrFviECQEyolW1gDRy765PZosL2alSSGK8V10Y7BGfOQyZUDgmnjQ==
 
-cypress@*, cypress@^12.14.0, cypress@^12.17.4:
+cypress@*, cypress@^12.14.0:
   version "12.14.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.14.0.tgz#37a19b85f5e9d881995e9fee1ddf41b3d3a623dd"
   integrity sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==
@@ -9694,6 +9723,54 @@ cypress@*, cypress@^12.14.0, cypress@^12.17.4:
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
     semver "^7.3.2"
+    supports-color "^8.1.1"
+    tmp "~0.2.1"
+    untildify "^4.0.0"
+    yauzl "^2.10.0"
+
+cypress@12.17.3:
+  version "12.17.3"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.3.tgz#1e2b19037236fc60e4a4b3a14f0846be17a1fc0e"
+  integrity sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==
+  dependencies:
+    "@cypress/request" "^2.88.11"
+    "@cypress/xvfb" "^1.2.4"
+    "@types/node" "^16.18.39"
+    "@types/sinonjs__fake-timers" "8.1.1"
+    "@types/sizzle" "^2.3.2"
+    arch "^2.2.0"
+    blob-util "^2.0.2"
+    bluebird "^3.7.2"
+    buffer "^5.6.0"
+    cachedir "^2.3.0"
+    chalk "^4.1.0"
+    check-more-types "^2.24.0"
+    cli-cursor "^3.1.0"
+    cli-table3 "~0.6.1"
+    commander "^6.2.1"
+    common-tags "^1.8.0"
+    dayjs "^1.10.4"
+    debug "^4.3.4"
+    enquirer "^2.3.6"
+    eventemitter2 "6.4.7"
+    execa "4.1.0"
+    executable "^4.1.1"
+    extract-zip "2.0.1"
+    figures "^3.2.0"
+    fs-extra "^9.1.0"
+    getos "^3.2.1"
+    is-ci "^3.0.0"
+    is-installed-globally "~0.4.0"
+    lazy-ass "^1.6.0"
+    listr2 "^3.8.3"
+    lodash "^4.17.21"
+    log-symbols "^4.0.0"
+    minimist "^1.2.8"
+    ospath "^1.2.2"
+    pretty-bytes "^5.6.0"
+    proxy-from-env "1.0.0"
+    request-progress "^3.0.0"
+    semver "^7.5.3"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
@@ -23692,6 +23769,16 @@ tough-cookie@^4.0.0:
     punycode "^2.1.1"
     universalify "^0.1.2"
 
+tough-cookie@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 tr46@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
@@ -24100,6 +24187,11 @@ universalify@^0.1.0, universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -24207,7 +24299,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.5.10:
+url-parse@^1.5.10, url-parse@^1.5.3:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==


### PR DESCRIPTION
Synpress released the new version to fix the webpack compilation when the test runs. Now we don't need to add Cypress in resolutions to fix the required version for the synpress. 
Two flaky tests have been skipped and a relevant task against this issue has been created as
https://www.notion.so/kumos/Stability-Pools-adjust-transaction-failing-in-first-attempt-at-dev-chain-ac28db1884684833bb104461e5e78149?pvs=4