### PR TITLE
CI: Split frontend tests from SDK workflow

### DIFF
--- a/.github/workflows/generic-skip.yaml
+++ b/.github/workflows/generic-skip.yaml
@@ -1,4 +1,4 @@
-name: Test contracts (Generic Skip)
+name: Generic Skip for [test-contracts]
 # Handles skipped but required checks
 
 on:
@@ -7,7 +7,7 @@ on:
       - "packages/contracts/**"
 
 jobs:
-  test:
+  test-contracts:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No tests required" '

--- a/.github/workflows/release-test-sdk.yml
+++ b/.github/workflows/release-test-sdk.yml
@@ -1,4 +1,4 @@
-name: Release SDK & UI
+name: Release and test SDK & UI
 
 env:
   CI: true
@@ -42,7 +42,7 @@ jobs:
             echo "{publish}={false}" >> $GITHUB_OUTPUT
           fi
 
-  test:
+  test-sdk:
     name: Run SDK
     runs-on: ubuntu-latest
     needs: workflow-setup
@@ -67,7 +67,7 @@ jobs:
       #   if: ${{ github.ref == 'refs/heads/main' }}
       #   run: yarn test-live
 
-  release:
+  release-sdk:
     name: Publish SDK to NPM and build Frontend image
     if: needs.workflow-setup.outputs.publish == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/release-test-sdk.yml
+++ b/.github/workflows/release-test-sdk.yml
@@ -6,16 +6,20 @@ env:
 
 on:
   push:
+    branches: ['main', 'dev']
     paths-ignore:
       - 'docs/**'
+      - 'packages/dev-frontend/**'
       - 'packages/contracts/**'
       - 'README.md'
       - 'LICENSE'
       - 'papers/**'
       - 'images/**'
   pull_request:
+    branches: ['main', 'dev']
     paths-ignore:
       - 'docs/**'
+      - 'packages/dev-frontend/**'
       - 'packages/contracts/**'
       - 'README.md'
       - 'LICENSE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ on:
       - 'images/**'
   pull_request:
     paths-ignore:
-
       - 'docs/**'
       - 'packages/contracts/**'
       - 'README.md'
@@ -44,7 +43,7 @@ jobs:
           fi
 
   test:
-    name: Run SDK, Frontend tests
+    name: Run SDK
     runs-on: ubuntu-latest
     needs: workflow-setup
     steps:
@@ -59,38 +58,10 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - name: Install linux deps
-        run: |
-          sudo apt-get install --no-install-recommends -y \
-          fluxbox \
-          xvfb
-
       - name: Run SDK tests
         run: |
           yarn test:lib-base &
           yarn test:lib-ethers
-
-      - name: Run e2e tests (synpress-action)
-        run: |
-          Xvfb :0 -screen 0 1024x768x24 -listen tcp -ac &
-          fluxbox &
-          yarn test:dev-frontend
-        env:
-          SECRET_WORDS: 'test test test test test test test test test test test junk'
-          NETWORK_NAME: 'Localhost'
-          RPC_URL: 'http://127.0.0.1:8545'
-          CHAIN_ID: 17
-          SYMBOL: 'ETH'
-          DISPLAY: :0.0
-
-      - name: Archive e2e artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v2
-        if: always()
-        with:
-          name: e2e-artifacts
-          path: |
-            ./packages/dev-frontend/tests/e2e/videos
-        continue-on-error: true
 
       # - name: Test SDK integration against live contracts
       #   if: ${{ github.ref == 'refs/heads/main' }}
@@ -100,7 +71,7 @@ jobs:
     name: Publish SDK to NPM and build Frontend image
     if: needs.workflow-setup.outputs.publish == 'true'
     runs-on: ubuntu-latest
-    needs: [ workflow-setup, test ]
+    needs: [ workflow-setup, test-sdk ]
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -6,10 +6,12 @@ env:
 
 on:
   push:
+    branches: ['main', 'dev']
     paths:
       - ".github/workflows/test-contracts.yml"
       - "packages/contracts/**"
   pull_request:
+    branches: ['main', 'dev']
     paths:
       - ".github/workflows/test-contracts.yml"
       - "packages/contracts/**"

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -15,7 +15,7 @@ on:
       - "packages/contracts/**"
 
 jobs:
-  test:
+  test-contracts:
     runs-on: ubuntu-latest
 
     # This condition checks if the pull request is not a draft
@@ -38,7 +38,7 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=4096
 
-  coverage:
+  test-coverage:
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'coverage') }}
     continue-on-error: true

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -5,14 +5,8 @@ env:
   FORCE_COLOR: true
 
 on:
-  push:
-    paths:
-      - ".github/workflows/test-frontend.yml"
-      - 'packages/dev-frontend/**'
-      - 'packages/lib-react/**'
-      - 'packages/lib-ethers/**'
-      - 'packages/providers/**'
   pull_request:
+    branches: ['main', 'dev']
     paths:
       - ".github/workflows/test-frontend.yml"
       - 'packages/dev-frontend/**'

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -1,0 +1,70 @@
+name: Test Frontend (e2e)
+
+env:
+  CI: true
+  FORCE_COLOR: true
+
+on:
+  push:
+    paths:
+      - ".github/workflows/test-frontend.yml"
+      - 'packages/dev-frontend/**'
+      - 'packages/lib-react/**'
+      - 'packages/lib-ethers/**'
+      - 'packages/providers/**'
+  pull_request:
+    paths:
+      - ".github/workflows/test-frontend.yml"
+      - 'packages/dev-frontend/**'
+      - 'packages/lib-react/**'
+      - 'packages/lib-ethers/**'
+      - 'packages/providers/**'
+jobs:
+
+  test-frontend:
+    # This condition checks if the pull request is not a draft
+    if: github.event.pull_request.draft == false
+
+    name: Run Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: 18.17.1
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - name: Install linux deps
+        run: |
+          sudo apt-get install --no-install-recommends -y \
+          fluxbox \
+          xvfb
+
+      - name: Run e2e tests (synpress-action)
+        run: |
+          Xvfb :0 -screen 0 1024x768x24 -listen tcp -ac &
+          fluxbox &
+          yarn test:dev-frontend
+        env:
+          SECRET_WORDS: 'test test test test test test test test test test test junk'
+          NETWORK_NAME: 'Localhost'
+          RPC_URL: 'http://127.0.0.1:8545'
+          CHAIN_ID: 17
+          SYMBOL: 'ETH'
+          DISPLAY: :0.0
+
+      - name: Archive e2e artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v2
+        if: always()
+        with:
+          name: e2e-artifacts
+          path: |
+            ./packages/dev-frontend/tests/e2e/videos
+        continue-on-error: true
+
+


### PR DESCRIPTION
Since frontend tests often fail due to simulation nature, for 
example issues with timeouts or the metamask simulation,
we want to separate them to be able to estimate the impact of
failed jobs. 

This PR aims to further solve https://github.com/kumodao/kumo-protocol/issues/373
